### PR TITLE
Suggestion for the new doctest API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MATLAB_PKG_DIR=doctest-matlab-0.4.0-dev
 SHELL = '/bin/bash'
 
 test:
-	octave --path inst --path inst/private --eval "[~, total_fail, total_extract_err] = doctest('doctest', 'doctest_run', 'doctest_compare'); exit(total_fail + total_extract_err > 0);"
+	octave --path inst --path inst/private --eval "success = doctest({'doctest', 'doctest_run', 'doctest_compare', 'doctest_collect', 'doctest_colors'}); exit(~success);"
 
 matlab_pkg:
 	mkdir -p tmp/${MATLAB_PKG_DIR}/private

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 doctest 0.4.0-dev
 =================
 
+  * Change doctest interface to be closer to Octave's test function.
+
 
 
 doctest 0.3.0 (2015-05-12)

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -185,8 +185,9 @@ function varargout = doctest(what, mode, fid)
 % Terminology
 % ===========
 %
-% A TARGET is a function, method or texinfo file. Each TARGET comes with a
-% docstring consisting of multiple DOCTESTS, i.e. question-answer snippets.
+% A TARGET is a function, method, class or texinfo file.  Each TARGET comes
+% with a docstring consisting of multiple DOCTESTS, i.e., question-answer
+% snippets.
 %
 %
 % History

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -229,6 +229,14 @@ end
 % get terminal color codes
 [color_ok, color_err, color_warn, reset] = doctest_colors();
 
+% determine if runing with octave
+try
+  OCTAVE_VERSION;
+  running_octave = 1;
+catch
+  running_octave = 0;
+end
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Collect all targets to be tested.
@@ -247,16 +255,30 @@ summary.num_targets = length(targets);
 summary.num_targets_passed = summary.num_targets_without_tests = summary.num_targets_with_extraction_errors = 0;
 summary.num_tests = summary.num_tests_passed = 0;
 
+% if running with octave and printing to stdout: buffer all output to work around issue #6
+run_buffered = running_octave && fid == stdout;
+if run_buffered
+  progress_buffer = '';
+end
+
+% print warning banner to stdout when running octave
+if running_octave
+  fprintf('==========================================================================\n');
+  fprintf('Start of temporary output (github.com/catch22/octave-doctest/issues/6)\n');
+  fprintf('==========================================================================\n');
+end
+
+% run all tests
 for i=1:numel(targets)
   % run doctests for target and update statistics
   target = targets(i);
-  fprintf(fid, '%s %s ', target.name, repmat('.', 1, 55 - numel(target.name)));
+  progress_printf('%s %s ', target.name, repmat('.', 1, 55 - numel(target.name)));
 
   % extraction error?
   if target.error
     summary.num_targets_with_extraction_errors = summary.num_targets_with_extraction_errors + 1;
-    fprintf(fid, [color_err  'EXTRACTION ERROR' reset '\n\n']);
-    fprintf(fid, '    %s\n\n', target.error);
+    progress_printf([color_err  'EXTRACTION ERROR' reset '\n\n']);
+    progress_printf('    %s\n\n', target.error);
     continue;
   end
 
@@ -284,20 +306,32 @@ for i=1:numel(targets)
 
   % pretty print outcome
   if num_tests == 0
-    fprintf(fid, 'NO TESTS\n');
+    progress_printf('NO TESTS\n');
   elseif num_tests_passed == num_tests
-    fprintf(fid, [color_ok 'PASS %4d/%-4d' reset '\n'], num_tests_passed, num_tests);
+    progress_printf([color_ok 'PASS %4d/%-4d' reset '\n'], num_tests_passed, num_tests);
   else
-    fprintf(fid, [color_err 'FAIL %4d/%-4d' reset '\n\n'], num_tests - num_tests_passed, num_tests);
+    progress_printf([color_err 'FAIL %4d/%-4d' reset '\n\n'], num_tests - num_tests_passed, num_tests);
     for j = 1:num_tests
       if ~results(j).passed
-        fprintf(fid, '   >> %s\n\n', results(j).source);
-        fprintf(fid, [ '      expected: ' '%s' '\n' ], results(j).want);
-        fprintf(fid, [ '      got     : ' color_err '%s' reset '\n' ], results(j).got);
-        fprintf(fid, '\n');
+        progress_printf('   >> %s\n\n', results(j).source);
+        progress_printf([ '      expected: ' '%s' '\n' ], results(j).want);
+        progress_printf([ '      got     : ' color_err '%s' reset '\n' ], results(j).got);
+        progress_printf('\n');
       end
     end
   end
+end
+
+% print warning banner to stdout when running octave
+if running_octave
+  fprintf('==========================================================================\n');
+  fprintf('End of temporary output (github.com/catch22/octave-doctest/issues/6)\n');
+  fprintf('==========================================================================\n\n');
+end
+
+% if running with octave, flush output buffer
+if run_buffered
+  fprintf(fid, '%s', progress_buffer);
 end
 
 
@@ -321,6 +355,17 @@ if nargout == 1
   varargout = {summary.num_targets_passed == summary.num_targets};
 elseif nargout > 1
   varargout = {summary.num_tests_passed, summary.num_tests, summary};
+end
+
+
+function progress_printf(template, varargin)
+  str = sprintf(template, varargin{:});
+  if run_buffered
+    progress_buffer = strcat({progress_buffer}, {str});
+    progress_buffer = progress_buffer{1};
+  else
+    fprintf(fid, str);
+  end
 end
 
 end

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -227,7 +227,7 @@ if nargin < 3
 end
 
 % get terminal color codes
-[color_ok, color_err, color_warn, reset] = doctest_colors();
+[color_ok, color_err, color_warn, reset] = doctest_colors(fid);
 
 % determine if runing with octave
 try

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -235,7 +235,7 @@ end
 % that docstring
 %
 
-[color_ok, color_err, color_warn, reset] = terminal_escapes();
+[color_ok, color_err, color_warn, reset] = doctest_colors();
 
 all_results = cell(1, length(to_test));
 all_extract_err = zeros(1, length(to_test));
@@ -330,7 +330,7 @@ for i = 1:total
   end
 end
 
-[color_ok, color_err, color_warn, reset] = terminal_escapes();
+[color_ok, color_err, color_warn, reset] = doctest_colors();
 
 if total == 0 && extract_err < 0
   fprintf(err, ['%s: ' color_warn  'Warning: could not extract tests' reset '\n'], to_test.name);
@@ -480,31 +480,4 @@ function [docstring, err, msg] = octave_extract_doctests(name)
   docstring = regexprep(docstring, '^\s*@example\n', '', 'lineanchors');
   docstring = regexprep(docstring, '^\s*@end example\n', '', 'lineanchors');
   docstring = regexprep(docstring, '@result\s*{}', '');
-end
-
-
-function [color_ok, color_err, color_warn, reset] = terminal_escapes()
-
-  try
-    OCTAVE_VERSION;
-    running_octave = 1;
-  catch
-    running_octave = 0;
-  end
-
-  if (running_octave)
-    have_colorterm = index(getenv('TERM'), 'color') > 0;
-    if have_colorterm
-      % terminal escapes for Octave color, hide from Matlab inside eval
-      color_ok = eval('"\033[1;32m"');    % green
-      color_err = eval('"\033[1;31m"');   % red
-      color_warn = eval('"\033[1;35m"');  % purple
-      reset = eval('"\033[m"');
-    end
-  else
-    color_ok = '';
-    color_err = '';
-    color_warn = '';
-    reset = '';
-  end
 end

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -424,7 +424,6 @@ function [docstring, err, msg] = octave_extract_doctests(name)
     [S, ~, ~, ~, ~, ~, ~] = regexp(L, '@result\s*{}');
     Ires = ~cellfun(@isempty, S);
     if (nnz(Ires) == 0)
-      docstring
       err = -2;  msg = 'has @example blocks but neither ">>" nor "@result{}"';
       docstring = '';
       return

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -250,8 +250,11 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 summary = struct;
 summary.num_targets = length(targets);
-summary.num_targets_passed = summary.num_targets_without_tests = summary.num_targets_with_extraction_errors = 0;
-summary.num_tests = summary.num_tests_passed = 0;
+summary.num_targets_passed = 0;
+summary.num_targets_without_tests = 0;
+summary.num_targets_with_extraction_errors = 0;
+summary.num_tests = 0;
+summary.num_tests_passed = 0;
 
 % if running with octave and printing to stdout: buffer all output to work around issue #6
 run_buffered = running_octave && fid == stdout;

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -7,10 +7,8 @@ function varargout = doctest(what, mode, fid)
 % doctest WHAT
 % doctest WHAT normal
 % doctest(WHAT, MODE, FID)
-%
-% SUCCESS = doctest ...
-% [NUM_TESTS_PASSED, NUM_TESTS, SUMMARY] = doctest ...
-%
+% SUCCESS = doctest(...)
+% [NUM_TESTS_PASSED, NUM_TESTS, SUMMARY] = doctest(...)
 %
 % The parameter WHAT contains the name of the function or class for
 % which to run the doctests. When running with Octave, WHAT can be the
@@ -229,7 +227,7 @@ end
 % get terminal color codes
 [color_ok, color_err, color_warn, reset] = doctest_colors(fid);
 
-% determine if runing with octave
+% determine if running with octave
 try
   OCTAVE_VERSION;
   running_octave = 1;
@@ -263,9 +261,9 @@ end
 
 % print warning banner to stdout when running octave
 if running_octave
-  fprintf('==========================================================================\n');
+  fprintf('======================================================================\n');
   fprintf('Start of temporary output (github.com/catch22/octave-doctest/issues/6)\n');
-  fprintf('==========================================================================\n');
+  fprintf('======================================================================\n');
 end
 
 % run all tests
@@ -324,9 +322,9 @@ end
 
 % print warning banner to stdout when running octave
 if running_octave
-  fprintf('==========================================================================\n');
+  fprintf('====================================================================\n');
   fprintf('End of temporary output (github.com/catch22/octave-doctest/issues/6)\n');
-  fprintf('==========================================================================\n\n');
+  fprintf('====================================================================\n\n');
 end
 
 % if running with octave, flush output buffer

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -38,8 +38,9 @@ function varargout = doctest(what, mode, fid)
 %   SUMMARY.num_tests
 %   SUMMARY.num_tests_passed
 %
-% The latter is probably only relevant when using Texinfo on Octave, where
-% it indicates malformed @example blocks.
+% The field 'num_targets_with_extraction_errors' is probably only relevant
+% when using Texinfo documentation on Octave, where it typically indicates
+% malformed @example blocks.
 %
 %
 % Description

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -1,0 +1,206 @@
+function targets = doctest_collect(what)
+% Collect all targets for given name.
+%
+% The parameter WHAT is the name of a function or class. In the latter case,
+% all methods are tested. When running Octave, it can also be the filename of
+% a Texinfo file.
+%
+% Returns a structure array with the following fields:
+%
+%   TARGETS(i).name       Human-readable name of test.
+%   TARGETS(i).link       Hyperlink to test for use in Matlab.
+%   TARGETS(i).docstring  Associated docstring.
+%   TARGETS(i).error:     Contains error string if extraction failed.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+% determine whether we are running octave or matlab
+try
+  OCTAVE_VERSION;
+  running_octave = 1;
+catch
+  running_octave = 0;
+end
+
+
+% determine type of target
+if running_octave
+  [~, ~, ext] = fileparts(what);
+  if any(strcmpi(ext, {'.texinfo' '.texi' '.txi' '.tex'}))
+    type = 'texfile';
+  elseif exist(what, 'file') || exist(what, 'builtin');
+    type = 'function';
+  else
+    type = 'class';
+  end
+else
+  if exist(what, 'class')
+    type = 'class';
+  else
+    type = 'function';
+  end
+end
+
+
+% add target(s)
+if strcmp(type, 'function')
+  target = struct;
+  target.name = what;
+  if running_octave
+    target.link = '';
+  else
+    target.link = sprintf('<a href="matlab:editorservices.openAndGoToLine(''%s'', 1);">%s</a>', which(what), what);
+  end
+  [target.docstring, target.error] = extract_docstring(target.name);
+  targets = [target];
+
+elseif strcmp(type, 'class')
+  % add target for all methods
+  meths = methods(what);
+  targets = [];
+  for i=1:numel(meths)
+    target = struct;
+    if running_octave
+      target.name = sprintf('@%s/%s', what, meths{i});
+      target.link = '';
+    else
+      target.name = sprintf('%s.%s', what, meths{i});
+      target.link = sprintf('<a href="matlab:editorservices.openAndGoToFunction(''%s'', ''%s'');">%s</a>', which(what), meths{i}, target.name);
+    end
+    [target.docstring, target.error] = extract_docstring(target.name);
+    targets = [targets; target];
+  end
+
+else
+  % parse texinfo file
+  target.name = what;
+  target.link = '';
+  [target.docstring, target.error] = parse_texinfo(fileread(what));
+  targets = [target];
+end
+
+
+function [docstring, error] = extract_docstring(name)
+  if running_octave
+    [docstring, format] = get_help_text(name);
+    if strcmp(format, 'texinfo')
+      [docstring, error] = parse_texinfo(docstring);
+    else
+      error = '';
+    end
+  else
+    docstring = help(name);
+    error = '';
+  end    
+end
+
+function [docstring, error] = parse_texinfo(str)  
+  docstring = '';
+  error = '';
+
+  % Matlab parser unhappy with underscore, hide inside eval
+  %str = eval('__makeinfo__(str, "plain text")');
+
+  % strip @group, and escape sequences
+  str = regexprep(str, '^\s*@group\n', '\n', 'lineanchors');
+  str = regexprep(str, '@end group\n', '');
+  str = strrep(str, '@{', '{');
+  str = strrep(str, '@}', '}');
+  str = strrep(str, '@@', '@');
+
+  % no example blocks? not an error, but nothing to do
+  if (isempty(strfind(str, '@example')))
+    % error = 'no @example blocks';
+    return
+  end
+
+  % leave the @example lines in, may need them later
+  T = regexp(str, '(@example.*?@end example)', 'tokens');
+  if (isempty(T))
+    error = 'malformed @example blocks';
+    return
+  else
+    % flatten
+    for i=1:length(T)
+      assert(length(T{i}) == 1)
+      T{i} = T{i}{1};
+    end
+    str = strjoin(T, '\n');
+  end
+
+  if (isempty(str) || ~isempty(regexp(str, '^\s*$')))
+    error = 'empty @example blocks';
+    return
+  end
+
+  if (~isempty(strfind(str, '>>')))
+    %% Has '>>' indicators
+    % err = 1;  msg = 'used >>';
+  else
+    %% No '>>', split on @result
+    % err = 2;  msg = 'used @result splitting';
+    L = strsplit (str, '\n');
+
+    % mask for lines with @result in them
+    [S, ~, ~, ~, ~, ~, ~] = regexp(L, '@result\s*{}');
+    Ires = ~cellfun(@isempty, S);
+    if (nnz(Ires) == 0)
+      error = 'has @example blocks but neither ">>" nor "@result{}"';
+      return
+    end
+    if Ires(1)
+      error = 'no command: @result on first line?';
+      return
+    end
+    for i=1:length(L)
+      if (length(S{i}) > 1)
+        error = 'more than one @result on one line';
+        return
+      end
+    end
+
+    % mask for lines with @example in them
+    Iex_start = ~cellfun(@isempty, regexp(L, '@example'));
+    Iex_end = ~cellfun(@isempty, regexp(L, '@end example'));
+
+    % build a new mask for lines which we think are commands
+    I = zeros(size(Ires), 'logical');
+    start_of_block = false;
+    for i=1:length(L)-1
+      if Iex_start(i)
+        start_of_block = true;
+      end
+      if (start_of_block)
+        I(i) = true;
+      end
+      if Ires(i+1)
+        % Next line has an @result so mark this line with '>>'
+        I(i) = true;
+        start_of_block = false;
+      end
+    end
+    % remove @example/@end lines from commands
+    I(Iex_start) = false;
+    I(Iex_end) = false;
+
+    starts = [0 diff(I)] == 1;
+    for i=1:length(L)
+      if (I(i) && ~isempty(L{i}) && isempty(regexp(L{i}, '^\s+$', 'match')))
+        if (starts(i))
+          L{i} = ['>> ' L{i}];
+        else
+          L{i} = ['.. ' L{i}];
+        end
+      end
+    end
+    str = strjoin(L, '\n');
+    str = [str sprintf('\n')];
+  end
+  str = regexprep(str, '^\s*@example\n', '', 'lineanchors');
+  str = regexprep(str, '^\s*@end example\n', '', 'lineanchors');
+  str = regexprep(str, '@result\s*{}', '');
+
+  docstring = str;
+end
+
+end

--- a/inst/private/doctest_colors.m
+++ b/inst/private/doctest_colors.m
@@ -1,0 +1,30 @@
+function [color_ok, color_err, color_warn, reset] = doctest_colors()
+% Return terminal color codes to use for current invocation of doctest.
+%
+% FIXME: Shouldn't use colors if stdout is not a TTY.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+try
+  OCTAVE_VERSION;
+  running_octave = 1;
+catch
+  running_octave = 0;
+end
+
+if (running_octave)
+  have_colorterm = index(getenv('TERM'), 'color') > 0;
+  if have_colorterm
+    % hide terminal escapes from Matlab
+    color_ok = eval('"\033[1;32m"');    % green
+    color_err = eval('"\033[1;31m"');   % red
+    color_warn = eval('"\033[1;35m"');  % purple
+    reset = eval('"\033[m"');
+  end
+else
+  color_ok = '';
+  color_err = '';
+  color_warn = '';
+  reset = '';
+end
+
+end

--- a/inst/private/doctest_colors.m
+++ b/inst/private/doctest_colors.m
@@ -1,4 +1,4 @@
-function [color_ok, color_err, color_warn, reset] = doctest_colors()
+function [color_ok, color_err, color_warn, reset] = doctest_colors(fid)
 % Return terminal color codes to use for current invocation of doctest.
 %
 % FIXME: Shouldn't use colors if stdout is not a TTY.
@@ -11,9 +11,11 @@ catch
   running_octave = 0;
 end
 
+
 if (running_octave)
+  % only use colors when printing to stdout and when terminal supports colors (XXX: should really check if fid isatty)
   have_colorterm = index(getenv('TERM'), 'color') > 0;
-  if have_colorterm
+  if fid == stdout && have_colorterm
     % hide terminal escapes from Matlab
     color_ok = eval('"\033[1;32m"');    % green
     color_err = eval('"\033[1;31m"');   % red

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -11,7 +11,7 @@ function results = doctest_run(docstring)
 % results.source:   the source code that was run
 % results.want:     the desired output
 % results.got:      the output that was recieved
-% results.pass:     whether .want and .got match each other according to
+% results.passed:   whether .want and .got match each other according to
 %       doctest_compare.
 %
 
@@ -50,14 +50,14 @@ for i = 1:length(examples)
   results(i).source = examples{i}{1};
   results(i).want = strtrim(want_unspaced);
   results(i).got = strtrim(got_unspaced);
-  pass = doctest_compare(want_unspaced, got_unspaced);
+  passed = doctest_compare(want_unspaced, got_unspaced);
   % a list of acceptably-missing prefixes (allow customizing?)
   prefix = {'', 'ans = '};
   for ii = 1:length(prefix)
-    pass = doctest_compare([prefix{ii} want_unspaced], got_unspaced);
-    if pass, break, end
+    passed = doctest_compare([prefix{ii} want_unspaced], got_unspaced);
+    if passed, break, end
   end
-  results(i).pass = pass;
+  results(i).passed = passed;
 end
 
 end


### PR DESCRIPTION
See #37 and #31 for related discussion. The new summary format is as follows:

~~~
octave:5> doctest({'doctest', 'doctest_run', 'doctest_compare', 'doctest_collect', 'doctest_colors'})
doctest ................................................ PASS    6/6   
doctest_run ............................................ NO TESTS
doctest_compare ........................................ PASS    2/2   
doctest_collect ........................................ NO TESTS
doctest_colors ......................................... NO TESTS

Summary:

   PASS    8/8   

5/5 targets passed, 3 without tests.

octave:6> 
~~~

~~~
octave:4> doctest({'doctest', 'doctest_run', 'cat', 'doctest_compare', 'more', 'test.texinfo', 'doctest'})
doctest ................................................ PASS    6/6   
doctest_run ............................................ NO TESTS
cat .................................................... FAIL    1/3   

   >> [A, B]

      expected: 
      got     : ans = 1 1 0 0 1 1 0 0

doctest_compare ........................................ PASS    2/2   
more ................................................... NO TESTS
test.texinfo ........................................... EXTRACTION ERROR

    has @example blocks but neither ">>" nor "@result{}"

doctest ................................................ PASS    6/6   

Summary:

   FAIL    1/17  

5/7 targets passed, 2 without tests, 1 with extraction errors.

octave:5> 
~~~

Please see `doctest.m` for the API documentation. Some points of discussion:

1. I am now printing test results as we go. However, since the non-interactive fake evalc is still broken (thanks to Octave being broken) maybe I should revert this back to @cbm755's method? On the other hand, it's quite cumbersome when testing larger projects if one has to wait for 10 minutes until any test result is visible. On the third hand (...), this would be somewhat remedied by a future `__run_doctest_suite__`, as one could always `tail -f` the logfile.
2. There is a `fid` parameter as in Octave's `test` function which can be used to redirect all standard output, and detailed test summary is returned as the third output parameter. It should be possible to write a `rundoctests` or `__run_doctest_suite__` wrapper as desired by @oheim.
3. Currently, there is only a `normal` mode since `quiet` did not seem very useful in view of point 2.