### PR TITLE
Allow '***' to match empty string

### DIFF
--- a/inst/private/doctest_compare.m
+++ b/inst/private/doctest_compare.m
@@ -38,7 +38,7 @@ got = regexprep(got, '.\x08', '');
 want = strtrim(want);
 got = strtrim(got);
 
-if isempty(want) && isempty(got)
+if isempty(got) && (isempty(want) || strcmp(want, '***'))
     match = 1;
     return
 end


### PR DESCRIPTION
Fixes #46.