### PR TITLE
Implement doctest skip

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,9 @@ doctest 0.4.0-dev
 =================
 
   * Change doctest interface to be closer to Octave's test function.
-  
+
+  * Some doctests can be marked to skip by appending "% doctest: +SKIP".
+
   * Other bug fixes.
 
 

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -134,6 +134,18 @@ function varargout = doctest(what, mode, fid)
 % gives some freedom to, e.g., indent the code output as you wish.
 %
 %
+% Skipping tests
+% --------------
+%
+% You can skip certain tests by marking them with a special comment.  This
+% can be used, for example, for a test not expected to pass or to avoid
+% opening a figure window during automated testing.
+%
+% >> a = 6         % doctest: +SKIP
+% b = 42
+% >> plot(...)     % doctest: +SKIP
+%
+%
 % Limitations
 % ===========
 %

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -31,7 +31,7 @@ for i = 1:length(examples)
   assert (length(examples{i}) == 2);
 
   % this test marked for skip
-  if (regexp(examples{i}{1}, 'doctest: \+SKIP$'))
+  if (regexp(examples{i}{1}, '[#|%] doctest: \+SKIP$'))
     keep(i) = false;
   end
 end

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -31,7 +31,7 @@ for i = 1:length(examples)
   assert (length(examples{i}) == 2);
 
   % this test marked for skip
-  if (regexp(examples{i}{1}, '[#|%] doctest: \+SKIP$'))
+  if (regexp(examples{i}{1}, '[#|%] doctest: \+SKIP'))
     keep(i) = false;
   end
 end

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -23,10 +23,22 @@ example_re = [
     '((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)'];  % the output
 [~,~,~,~,examples] = regexp(docstring, example_re);
 
+
+% Some tests are marked to skip
+keep = ones(size(examples), 'logical');
 for i = 1:length(examples)
   % each block should be split into input/output by the regex
   assert (length(examples{i}) == 2);
 
+  % this test marked for skip
+  if (regexp(examples{i}{1}, 'doctest: \+SKIP$'))
+    keep(i) = false;
+  end
+end
+examples = examples(keep);
+
+
+for i = 1:length(examples)
   % split into lines
   lines = textscan(examples{i}{1}, '%s', 'delimiter', sprintf('\n'));
   lines = lines{1};

--- a/test/test_skip.m
+++ b/test/test_skip.m
@@ -1,0 +1,31 @@
+function y = test_skip()
+% This file should have 3 passed tests
+%
+% A test that would fail:
+% >> a = 5  % doctest: +SKIP
+% b = 7
+%
+%
+% And a passing one:
+% >> a = 6
+% a = 6
+%
+%
+% Multiline input:
+% >> A = [1 2;
+% ..      3 4]    % doctest: +SKIP
+% A = 42
+%
+%
+% Put it whether you want:
+% >> A = [1 2;    % doctest: +SKIP
+% ..      3 4]
+% A = 42
+%
+%
+% Skip means not evaluated
+% >> a = 6
+% a = 6
+% >> a = 5        % doctest: +SKIP
+% >> a
+% a = 6

--- a/test/test_skip.m
+++ b/test/test_skip.m
@@ -17,7 +17,7 @@ function y = test_skip()
 % A = 42
 %
 %
-% Put it whether you want:
+% Put it on any line of multiline input:
 % >> A = [1 2;    % doctest: +SKIP
 % ..      3 4]
 % A = 42

--- a/test/test_skip_only_one.m
+++ b/test/test_skip_only_one.m
@@ -1,0 +1,4 @@
+function y = test_skip_only_one()
+% A file with just one skipped test:
+% >> a = 5  % doctest: +SKIP
+% b = 7


### PR DESCRIPTION
Not yet tested with texinfo and no `@comment` support.

Should be merge-able or you can wait until I try the texinfo stuff...