### PR TITLE
extract error for "+SKIP" in a malformed @example block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OCTAVE ?= octave
 MKOCTFILE ?= mkoctfile -Wall
 MATLAB ?= matlab
 
-TEST_CODE=success = doctest({'doctest', 'test_blank_match', 'test_compare_backspace', 'test_compare_hyperlinks', 'test_ellipsis', 'test_skip', 'test_skip_only_one', 'test_warning', 'test_class', 'test_comments.texinfo', 'test_skip_comments.texinfo', 'test_xfail', 'test_xfail.texinfo', 'test_whitespace'}); exit(~success);
+TEST_CODE=success = doctest({'doctest', 'test_blank_match', 'test_compare_backspace', 'test_compare_hyperlinks', 'test_ellipsis', 'test_skip', 'test_skip_only_one', 'test_warning', 'test_class', 'test_comments.texinfo', 'test_skip_comments.texinfo', 'test_skip_malformed.texinfo', 'test_xfail', 'test_xfail.texinfo', 'test_whitespace'}); exit(~success);
 
 
 .PHONY: help test test-interactive matlab_test matlab_pkg

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -161,8 +161,15 @@ function [docstring, error] = parse_texinfo(str)
     S = regexp(L, '@result\s*{}');
     Ires = ~cellfun(@isempty, S);
     if (nnz(Ires) == 0)
-      error = 'has @example blocks but neither ">>" nor "@result{}"';
-      return
+      if (isempty(regexp(str, '% doctest: \+SKIP\n')))
+        error = 'has @example blocks but neither ">>" nor "@result{}"';
+        return
+      else
+        % PR #72: special case if no >>, no @result, but +SKIP is present.
+        % Don't raise extraction error; workaround could mask later errors
+        % but low risk (as someone has deliberately marked +SKIP).
+        return
+      end
     end
     if Ires(1)
       error = 'no command: @result on first line?';

--- a/test/test_skip_malformed.texinfo
+++ b/test/test_skip_malformed.texinfo
@@ -1,5 +1,7 @@
 @example
 @comment doctest: +SKIP
-Howdy, I'm some verbatim text masquerading as an example.
-I probably should live inside an @@verbatim block, but I don't...
+Some verbatim text masquerading as an example (probably should live inside
+an @@verbatim block, but isn't).
+
+Should not raise an extraction error, because it is marked to skip.
 @end example

--- a/test/test_skip_malformed.texinfo
+++ b/test/test_skip_malformed.texinfo
@@ -1,0 +1,5 @@
+@example
+@comment doctest: +SKIP
+Howdy, I'm some verbatim text masquerading as an example.
+I probably should live inside an @@verbatim block, but I don't...
+@end example


### PR DESCRIPTION
Tests marked `doctest: +SKIP` can nonetheless raise Extraction Errrors.

No fix yet, just the test itself ;-)

*Background:* This happens a lot in core octave where `@example` seems to be often used as `@verbatim` and in particular as the alternative to `@tex` when writing mathematics.  Maybe they should just use `@verbatim` but its not so easy because that changes indentation.  Easier at least in the short term to just mark them as `doctest: +SKIP`.