### PR TITLE
Change to NORMALIZE_WHITESPACE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,11 +8,11 @@ doctest 0.4.0-dev
   * Doctests can be marked as expected to fail with "% doctest: +XFAIL".
 
   * Add a mode for stricter whitespace checking: enable with
-    "% doctest: -NORMALIZEWHITESPACE".
+    "% doctest: -NORMALIZE_WHITESPACE".
 
   * Add a mode to disable "..." wildcards: enable with "% doctest: -ELLIPSIS".
 
-  * Improve evalc implementatoin (Octave).
+  * Improve evalc implementation on Octave.
 
   * Other bug fixes.
 

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -146,11 +146,11 @@ function varargout = doctest(what)
 % before comparison.  A stricter mode where "internal whitespace" must
 % match is available:
 %
-% >> fprintf('a   b\nc   d\n')    % doctest: -NORMALIZEWHITESPACE
+% >> fprintf('a   b\nc   d\n')    % doctest: -NORMALIZE_WHITESPACE
 % a   b
 % c   d
 %
-% >> fprintf('a  b\nc  d\n')      % doctest: +NORMALIZEWHITESPACE
+% >> fprintf('a  b\nc  d\n')      % doctest: +NORMALIZE_WHITESPACE
 % a b
 % c d
 %

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -26,7 +26,7 @@ example_re = [
 % default options
 skip = false(size(examples));
 xfail = false(size(examples));
-normalizewhitespace = true(size(examples));
+normalize_whitespace = true(size(examples));
 ellipsis = true(size(examples));
 
 % parse directives
@@ -46,8 +46,8 @@ for i = 1:length(examples)
       skip(i) = enable;
     elseif strcmp(directive, 'XFAIL')
       xfail(i) = enable;
-    elseif strcmp(directive, 'NORMALIZEWHITESPACE')
-      normalizewhitespace(i) = enable;
+    elseif strcmp(directive, 'NORMALIZE_WHITESPACE')
+      normalize_whitespace(i) = enable;
     elseif strcmp(directive, 'ELLIPSIS')
       ellipsis(i) = enable;
     else
@@ -59,7 +59,7 @@ end
 % remove skipped tests
 examples = examples(~skip);
 xfail = xfail(~skip);
-normalizewhitespace = normalizewhitespace(~skip);
+normalize_whitespace = normalize_whitespace(~skip);
 ellipsis = ellipsis(~skip);
 
 % replace initial '..' by '  ' in subsequent lines
@@ -83,7 +83,7 @@ all_outputs = DOCTEST__evalc(examples);
 
 % deal with whitespace in inputs and outputs
 for i = 1:length(examples)
-  if (normalizewhitespace(i))
+  if (normalize_whitespace(i))
     % collapse multiple spaces to one
     examples{i}{2} = strtrim(regexprep(examples{i}{2}, '\s+', ' '));
     all_outputs{i} = strtrim(regexprep(all_outputs{i}, '\s+', ' '));

--- a/test/test_whitespace.m
+++ b/test/test_whitespace.m
@@ -1,23 +1,23 @@
 function test_whitespace()
-% >> disp('a   b')    % doctest: -NORMALIZEWHITESPACE
+% >> disp('a   b')    % doctest: -NORMALIZE_WHITESPACE
 % a   b
 %
-% >> disp('a   b')    % doctest: +NORMALIZEWHITESPACE
+% >> disp('a   b')    % doctest: +NORMALIZE_WHITESPACE
 % a b
-% >> disp('a   b')    % doctest: +NORMALIZEWHITESPACE
+% >> disp('a   b')    % doctest: +NORMALIZE_WHITESPACE
 % a       b
 %
 %
 % Indenting is ok:
 %
-% >> disp('a   b')    % doctest: -NORMALIZEWHITESPACE
+% >> disp('a   b')    % doctest: -NORMALIZE_WHITESPACE
 %
 %    a   b
 %
 %
 % But this should fail:
 %
-% >> disp('a   b')    % doctest: -NORMALIZEWHITESPACE   % doctest: +XFAIL
+% >> disp('a   b')    % doctest: -NORMALIZE_WHITESPACE   % doctest: +XFAIL
 %
 %    a b
 %
@@ -25,13 +25,13 @@ function test_whitespace()
 % Multiline: Matlab and Octave format matrices differently but a
 % column vector is safe to use in cross-platform tests.
 %
-% >> A = [1; 2; -3]   % doctest: -NORMALIZEWHITESPACE
+% >> A = [1; 2; -3]   % doctest: -NORMALIZE_WHITESPACE
 % A =
 %   1
 %   2
 %  -3
 %
-% >> A                % doctest: -NORMALIZEWHITESPACE
+% >> A                % doctest: -NORMALIZE_WHITESPACE
 %
 % A =
 %
@@ -45,9 +45,9 @@ function test_whitespace()
 % Matlab and Octave format differently, even for scalars, so
 % make sure our auto "ans = " bit still works.
 %
-% >> 42                 % doctest: -NORMALIZEWHITESPACE
+% >> 42                 % doctest: -NORMALIZE_WHITESPACE
 % 42
 %
 %
 % Note: even very simple scalar tests like "x = 5" are difficult to
-% pass in both Octave and Matlab when using -NORMALIZEWHITESPACE.
+% pass in both Octave and Matlab when using -NORMALIZE_WHITESPACE.


### PR DESCRIPTION
This is more consistent with Python.

Fixes #76.  Also fix minor typo in NEWS.