### PR TITLE
Allow default values for directives to be overriden on cmdline

### DIFF
--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -1,4 +1,4 @@
-function varargout = doctest(what)
+function varargout = doctest(what, varargin)
 % Run examples embedded in documentation
 %
 % Usage
@@ -157,6 +157,10 @@ function varargout = doctest(what)
 %
 % To disable the '...' wildcard, use the -ELLIPSIS directive.
 %
+% The default directives can be overridden on the command line using, for
+% example, "doctest target -NORMALIZE_WHITESPACE +ELLIPSIS".  Note that
+% directives local to a test still take precident of these.
+%
 %
 % Testing Texinfo documentation
 % =============================
@@ -218,6 +222,23 @@ if ~iscell(what)
   what = {what};
 end
 
+% input parsing for options and directives
+directives = doctest_default_directives();
+for i = 1:(nargin-1)
+  assert(ischar(varargin{i}))
+  pm = varargin{i}(1);
+  directive = varargin{i}(2:end);
+  switch directive
+    case 'recursive'
+      assert(strcmp(pm, '-'))
+      error('recursion not implemented yet')
+    otherwise
+      assert(strcmp(pm, '+') || strcmp(pm, '-'))
+      enable = strcmp(varargin{i}(1), '+');
+      directives = doctest_default_directives(directives, directive, enable);
+  end
+end
+
 % for now, always print to stdout
 fid = 1;
 
@@ -263,7 +284,7 @@ for i=1:numel(targets)
   end
 
   % run doctest
-  results = doctest_run(target.docstring);
+  results = doctest_run(target.docstring, directives);
 
   % determine number of tests passed
   num_tests = numel(results);

--- a/inst/private/doctest_default_directives.m
+++ b/inst/private/doctest_default_directives.m
@@ -1,0 +1,36 @@
+function d = doctest_default_directives(varargin)
+%DOCTEST_DEFAULT_DIRECTIVES  Return/set defaults directives
+%   Possible calling forms:
+%     dirs = doctest_default_directives()
+%     dirs = doctest_default_directives('ellipsis', true)
+%     dirs = doctest_default_directives(dirs, 'ellipsis', true)
+%   See source/documentation for valid directives.
+
+  defaults.normalize_whitespace = true;
+  defaults.ellipsis = true;
+
+  if (nargin == 0)
+    d = defaults;
+    return
+  elseif (nargin == 2)
+    d = defaults;
+    directive = varargin{1};
+    enable = varargin{2};
+  elseif (nargin == 3)
+    d = varargin{1};
+    directive = varargin{2};
+    enable = varargin{3};
+  else
+    error('invalid input')
+  end
+
+  switch directive
+    case 'ELLIPSIS'
+      d.ellipsis = enable;
+    case 'NORMALIZE_WHITESPACE'
+      d.normalize_whitespace = enable;
+    otherwise
+      error('invalid directive "%s"', directive)
+  end
+
+end

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -1,4 +1,4 @@
-function results = doctest_run(docstring)
+function results = doctest_run(docstring, defaults)
 %DOCTEST_RUN - used internally by doctest
 %
 % Usage:
@@ -26,8 +26,8 @@ examples = regexp(docstring, example_re, 'tokens');
 % default options
 skip = false(size(examples));
 xfail = false(size(examples));
-normalize_whitespace = true(size(examples));
-ellipsis = true(size(examples));
+normalize_whitespace = defaults.normalize_whitespace .* true(size(examples));
+ellipsis = defaults.ellipsis .* true(size(examples));
 
 % parse directives
 for i = 1:length(examples)


### PR DESCRIPTION
Fixes #74.

@catch22 this adds some input parsing.  Is it compatible with your plans?  Or you have a better way?
I left a stub for future `-recursive`.

I did not allow settings defaults for XFAIL and SKIP could do so.