### PR TITLE
[WIP] texinfo: wip to expand @var macros

### DIFF
--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -270,8 +270,7 @@ function [docstring, error] = parse_texinfo(str)
     str = strjoin(T, '\n');
   end
 
-  % replace @var{abc} with ABC: unfortunately '${upper($1)}' doesn't work on
-  % Octave so for now @var{abc} goes to abc.
+  % replace @var{abc} with abc
   str = regexprep(str, '\@var\{(\w+)\}', '$1');
 
   if (isempty(str) || ~isempty(regexp(str, '^\s*$')))

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -270,6 +270,10 @@ function [docstring, error] = parse_texinfo(str)
     str = strjoin(T, '\n');
   end
 
+  % replace @var{abc} with ABC: unfortunately '${upper($1)}' doesn't work on
+  % Octave so for now @var{abc} goes to abc.
+  str = regexprep(str, '\@var\{(\w+)\}', '$1');
+
   if (isempty(str) || ~isempty(regexp(str, '^\s*$')))
     error = 'empty @example blocks';
     return

--- a/test/test_var_replace.texinfo
+++ b/test/test_var_replace.texinfo
@@ -2,15 +2,7 @@
 @group
 @var{ABC} = 6
 @result{} @var{ABC} = 6
-@end group
-@end example
-
-Different cases:
-@example
-@group
-@var{abc} = 7
-@result{} ABC = 7
-@var{aBc} = 8
-@result{} ABC = 8
+@var{aBc} = 7
+@result{} @var{aBc} = 7
 @end group
 @end example

--- a/test/test_var_replace.texinfo
+++ b/test/test_var_replace.texinfo
@@ -1,0 +1,16 @@
+@example
+@group
+@var{ABC} = 6
+@result{} @var{ABC} = 6
+@end group
+@end example
+
+Different cases:
+@example
+@group
+@var{abc} = 7
+@result{} ABC = 7
+@var{aBc} = 8
+@result{} ABC = 8
+@end group
+@end example


### PR DESCRIPTION
Partial fix for #102 except that Octave doesn't seem to support
uppercasing in regexp :(

