### PR TITLE
Ignore hidden dirs, and non .m/texinfo files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,11 @@ doctest 0.4.1-dev
       - Allow arbitrary TexInfo macros.  The documentation is interpreted
         by makeinfo before running the code examples.
 
+  * Improved folder/directory traversals:
+
+      - Ignore hidden (dot) directories.
+      - Ignore files that are neither m-files nor texinfo.
+
 
 
 doctest 0.4.0 (2015-07-02)

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -57,9 +57,9 @@ end
 
 % Deal with directories
 if (strcmp(type, 'dir'))
-  if (~ strcmp(what, '.'))
-    fprintf(fid, 'Descending into directory "%s"\n', what);
-  end
+  %if (~ strcmp(what, '.'))
+  %  fprintf(fid, 'Descending into directory "%s"\n', what);
+  %end
   oldcwd = chdir(what);
   files = dir('.');
   for i=1:numel(files)
@@ -75,11 +75,11 @@ if (strcmp(type, 'dir'))
         % skip all directories
         continue
       elseif (strcmp(f(1), '.'))
-        fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
+        %fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
         continue
       elseif (strcmpi(f, 'private'))
         % running code in private dirs may need mucking around with path
-        fprintf(fid, 'Ignoring directory "%s"\n', f)
+        %fprintf(fid, 'Ignoring directory "%s"\n', f)
         continue
       end
     else

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -56,9 +56,15 @@ else % Matlab
     type = 'dir';
   elseif exist(what, 'file') || exist(what, 'builtin');
     type = 'function';
+  elseif ~isempty(help(what))
+    % covers "doctest class.method" and "doctest class/method"
+    type = 'function'
   else
     type = 'unknown';
   end
+  % Note: ambiguous what happens for "doctest @class/method"... as is
+  % "help @class/method", e.g., "help @class/class" does not give the
+  % constructors
 end
 
 

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -68,7 +68,7 @@ if (strcmp(type, 'dir'))
       if strcmp(f, '.') || strcmp(f, '..') || strcmpi(f, 'private')
         % skip ., .., and private folders (TODO)
         continue
-      elseif (f(1) == '@')
+      elseif (strcmp(f(1), '@'))
         % strip @ to prevent processing as a directory
         f = f(2:end);
       elseif (~ recursive)

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -65,8 +65,8 @@ if (strcmp(type, 'dir'))
   for i=1:numel(files)
     f = files(i).name;
     if (exist(f, 'dir'))
-      if strcmp(f, '.') || strcmp(f, '..') || strcmpi(f, 'private')
-        % skip ., .., and private folders (TODO)
+      if (strcmp(f, '.') || strcmp(f, '..'))
+        % skip "." and ".."
         continue
       elseif (strcmp(f(1), '@'))
         % strip @ to prevent processing as a directory
@@ -76,6 +76,10 @@ if (strcmp(type, 'dir'))
         continue
       elseif (strcmp(f(1), '.'))
         fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
+        continue
+      elseif (strcmpi(f, 'private'))
+        % running code in private dirs may need mucking around with path
+        fprintf(fid, 'Ignoring directory "%s"\n', f)
         continue
       end
     else

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -230,7 +230,23 @@ function [docstring, error] = extract_docstring(name)
     [docstring, format] = get_help_text(name);
     if strcmp(format, 'texinfo')
       [docstring, error] = parse_texinfo(docstring);
+    elseif strcmp(format, 'plain text')
+      error = '';
+    elseif strcmp(format, 'Not documented')
+      assert (isempty (docstring))
+      error = '';
+    elseif strcmp(format, 'Not found')
+      % looks like "doctest test_no_docs.m" gets us here: octave bug?
+      if (regexp(name,'\.m$'))
+        assert (isempty (docstring))
+        error = '';
+      else
+        assert (isempty (docstring))
+        error = 'Not an m file.';
+      end
     else
+      format
+      warning('Unexpected format in that file/function');
       error = '';
     end
   else

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -64,16 +64,23 @@ if (strcmp(type, 'dir'))
   files = dir('.');
   for i=1:numel(files)
     f = files(i).name;
-    if strcmp(f, '.') || strcmp(f, '..') || strcmpi(f, 'private')
-      % skip ., .., and private folders (TODO)
-      continue
-    end
-    if (f(1) == '@')
-      % strip the @, prevents processing as a directory
-      f = f(2:end);
-    elseif (~ recursive && exist(f, 'dir'))
-      % skip directories
-      continue
+    if (exist(f, 'dir'))
+      if strcmp(f, '.') || strcmp(f, '..') || strcmpi(f, 'private')
+        % skip ., .., and private folders (TODO)
+        continue
+      elseif (f(1) == '@')
+        % strip @ to prevent processing as a directory
+        f = f(2:end);
+      elseif (~ recursive)
+        % skip all directories
+        continue
+      end
+    else
+      [~, ~, ext] = fileparts(f);
+      if (~ any(strcmpi(ext, {'.m' '.texinfo' '.texi' '.txi' '.tex'})))
+        %fprintf(fid, 'Debug: ignoring file "%s"\n', f)
+        continue
+      end
     end
     summary = doctest_collect(f, directives, summary, recursive, fid);
   end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -62,9 +62,9 @@ else % Matlab
   else
     type = 'unknown';
   end
-  % Note: ambiguous what happens for "doctest @class/method"... as is
-  % "help @class/method", e.g., "help @class/class" does not give the
-  % constructors
+  % Note: ambiguous what happens for "doctest @class/method"... as it is
+  % for "help @class/method", e.g., "help @class/class" does not give the
+  % constructor's help.
 end
 
 
@@ -90,7 +90,8 @@ if (strcmp(type, 'dir'))
         %fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
         continue
       elseif (strcmpi(f, 'private'))
-        % running code in private dirs may need mucking around with path
+        % running code in private dirs may need mucking around with path,
+        % see related: https://savannah.gnu.org/bugs/?38776
         %fprintf(fid, 'Ignoring directory "%s"\n', f)
         continue
       end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -25,7 +25,10 @@ if is_octave()
     else
       type = 'function';
     end
-  elseif (exist(what, 'dir') && ~strcmp(what(1), '@'))
+  elseif (strcmp(what(1), '@'))
+    % comes after 'file' above for "doctest @class/method"
+    type = 'class';
+  elseif (exist(what, 'dir'))
     type = 'dir';
   elseif exist(what) == 2 || exist(what) == 103
     % Notes:
@@ -69,8 +72,7 @@ if (strcmp(type, 'dir'))
         % skip "." and ".."
         continue
       elseif (strcmp(f(1), '@'))
-        % strip @ to prevent processing as a directory
-        f = f(2:end);
+        % class, don't skip if nonrecursive
       elseif (~ recursive)
         % skip all directories
         continue
@@ -203,6 +205,10 @@ end
 
 
 function targets = collect_targets_class(what)
+  if (strcmp(what(1), '@'))
+    % Octave methods('@foo') gives java error, Matlab just says "No methods"
+    what = what(2:end);
+  end
   % First, "help class".  For classdef, this differs from "help class.class"
   % (general class help vs constructor help).  For old-style classes we will
   % probably end up testing the constructor twice but... meh.

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -89,11 +89,6 @@ if (strcmp(type, 'dir'))
       elseif (strcmp(f(1), '.'))
         %fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
         continue
-      elseif (strcmpi(f, 'private'))
-        % running code in private dirs may need mucking around with path,
-        % see related: https://savannah.gnu.org/bugs/?38776
-        %fprintf(fid, 'Ignoring directory "%s"\n', f)
-        continue
       end
     else
       [~, ~, ext] = fileparts(f);

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -25,7 +25,7 @@ if is_octave()
     else
       type = 'function';
     end
-  elseif (exist(what, 'dir') && what(1) ~= '@')
+  elseif (exist(what, 'dir') && ~strcmp(what(1), '@'))
     type = 'dir';
   elseif exist(what) == 2 || exist(what) == 103
     % Notes:

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -45,8 +45,12 @@ if is_octave()
       type = 'unknown';
     end
   end
-else
-  if ~isempty(methods(what))
+else % Matlab
+  if (strcmp(what(1), '@')) && ~isempty(methods(what(2:end)))
+    % covers "doctest @class", but not "doctest @class/method"
+    type = 'class';
+  elseif ~isempty(methods(what))
+    % covers "doctest class"
     type = 'class';
   elseif (exist(what, 'dir'))
     type = 'dir';

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -74,6 +74,9 @@ if (strcmp(type, 'dir'))
       elseif (~ recursive)
         % skip all directories
         continue
+      elseif (strcmp(f(1), '.'))
+        fprintf(fid, 'Ignoring hidden directory "%s"\n', f)
+        continue
       end
     else
       [~, ~, ext] = fileparts(f);

--- a/test/.hidden/test_dont_run.m
+++ b/test/.hidden/test_dont_run.m
@@ -1,0 +1,4 @@
+function test_dont_run()
+% This is in a dot directory so it should not run
+% >> a = 5
+% a = 6

--- a/test/@test_class/test_class.m
+++ b/test/@test_class/test_class.m
@@ -2,9 +2,14 @@ function obj = test_class
 %
 % >> class(test_class)
 % ans = test_class
+%
+%
+% >> methods test_class
+% Methods for class test_class:
+% test_class   test_method
 
 obj = struct;
-obj.name = 'My name';
+obj.name = 'Default Name';
 obj.age = 42;
 obj = class(obj, 'test_class');
 

--- a/test/@test_class/test_method.m
+++ b/test/@test_class/test_method.m
@@ -1,7 +1,7 @@
 function result = test_method(obj, varargin)
 %
 % >> m = test_class; test_method(m)
-% ans = My name is 42 years old.
+% ans = Default Name is 42 years old.
 
 result = sprintf('%s is %d years old.', obj.name, obj.age);
 

--- a/test/private/test_dont_run.m
+++ b/test/private/test_dont_run.m
@@ -1,0 +1,4 @@
+function test_dont_run()
+% This is in a private directory so it should not run
+% >> a = 5
+% a = 6

--- a/test/private/test_dont_run.m
+++ b/test/private/test_dont_run.m
@@ -1,4 +1,0 @@
-function test_dont_run()
-% This is in a private directory so it should not run
-% >> a = 5
-% a = 6

--- a/test/private/test_in_private_dir.m
+++ b/test/private/test_in_private_dir.m
@@ -1,0 +1,3 @@
+function test_in_private_dir()
+% >> a = 5
+% a = 5

--- a/test/test_no_docs.m
+++ b/test/test_no_docs.m
@@ -1,0 +1,4 @@
+function test_no_docs()
+
+  s = 'note this function has no docs: this should not cause an error';
+

--- a/test/test_not_an_mfile.txt
+++ b/test/test_not_an_mfile.txt
@@ -1,0 +1,9 @@
+% hello, I am not an m-file so I should not be doctested
+%
+% >> a = 6
+% a = 7
+%
+%
+% This test would fail if doctest finds it when traversing
+% a directory.  If you run doctest on it directly, you should
+% get an error.

--- a/test/test_shadow/test_in_shadow_dir.m
+++ b/test/test_shadow/test_in_shadow_dir.m
@@ -1,0 +1,12 @@
+function test_in_shadow_dir(x)
+% this test is in a directory shadowed/shadowing both a class
+% and an m-file.  Its probably not entirely well-posed what
+% should happen here but on Octave at least, you can doctest
+% all three.
+%
+% >> a = 4
+% a = 4
+% >> a = 5
+% a = 5
+% >> a = 6
+% a = 6


### PR DESCRIPTION
Some fixes for various bugs.  I did not add config flags: I figure we can add later if there is a use case...

Most importantly it stays out of one's `.git`