### PR TITLE
Add SKIP_BLOCKS_WO_OUTPUT directive

### DIFF
--- a/inst/private/doctest_default_directives.m
+++ b/inst/private/doctest_default_directives.m
@@ -7,6 +7,7 @@ function d = doctest_default_directives(varargin)
 %   See source/documentation for valid directives.
 
   defaults.normalize_whitespace = true;
+  defaults.ignore_blocks_wo_output = false;
   defaults.ellipsis = true;
 
   if (nargin == 0)
@@ -29,6 +30,8 @@ function d = doctest_default_directives(varargin)
       d.ellipsis = enable;
     case 'NORMALIZE_WHITESPACE'
       d.normalize_whitespace = enable;
+    case 'IGNORE_BLOCKS_WO_OUTPUT'
+      d.ignore_blocks_wo_output = enable;
     otherwise
       error('invalid directive "%s"', directive)
   end

--- a/inst/private/doctest_default_directives.m
+++ b/inst/private/doctest_default_directives.m
@@ -7,7 +7,7 @@ function d = doctest_default_directives(varargin)
 %   See source/documentation for valid directives.
 
   defaults.normalize_whitespace = true;
-  defaults.ignore_blocks_wo_output = false;
+  defaults.skip_blocks_wo_output = false;
   defaults.ellipsis = true;
 
   if (nargin == 0)
@@ -30,8 +30,8 @@ function d = doctest_default_directives(varargin)
       d.ellipsis = enable;
     case 'NORMALIZE_WHITESPACE'
       d.normalize_whitespace = enable;
-    case 'IGNORE_BLOCKS_WO_OUTPUT'
-      d.ignore_blocks_wo_output = enable;
+    case 'SKIP_BLOCKS_WO_OUTPUT'
+      d.skip_blocks_wo_output = enable;
     otherwise
       error('invalid directive "%s"', directive)
   end

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -43,7 +43,7 @@ for i=1:length(test_matches)
 
   % set default options
   tests(i).normalize_whitespace = defaults.normalize_whitespace;
-  tests(i).ignore_blocks_wo_output = defaults.ignore_blocks_wo_output;
+  tests(i).skip_blocks_wo_output = defaults.skip_blocks_wo_output;
   tests(i).ellipsis = defaults.ellipsis;
   tests(i).skip = {};
   tests(i).xfail = {};
@@ -64,8 +64,8 @@ for i=1:length(test_matches)
       tests(i).normalize_whitespace = strcmp(directive(1), '+');
     elseif strcmp('ELLIPSIS', directive(2:end))
       tests(i).ellipsis = strcmp(directive(1), '+');
-    elseif strcmp('IGNORE_BLOCKS_WO_OUTPUT', directive(2:end))
-      tests(i).ignore_blocks_wo_output = strcmp(directive(1), '+');
+    elseif strcmp('SKIP_BLOCKS_WO_OUTPUT', directive(2:end))
+      tests(i).skip_blocks_wo_output = strcmp(directive(1), '+');
     elseif strcmp('+SKIP', directive)
       tests(i).skip{end + 1} = 'true';
     elseif strcmp('+SKIP_IF', directive)
@@ -125,7 +125,7 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
   if DOCTEST__result.skip
      continue
   end
-  if DOCTEST__result.ignore_blocks_wo_output && isempty(DOCTEST__result.want)
+  if DOCTEST__result.skip_blocks_wo_output && isempty(DOCTEST__result.want)
     continue
   end
 

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -43,6 +43,7 @@ for i=1:length(test_matches)
 
   % set default options
   tests(i).normalize_whitespace = defaults.normalize_whitespace;
+  tests(i).ignore_blocks_wo_output = defaults.ignore_blocks_wo_output;
   tests(i).ellipsis = defaults.ellipsis;
   tests(i).skip = {};
   tests(i).xfail = {};
@@ -63,6 +64,8 @@ for i=1:length(test_matches)
       tests(i).normalize_whitespace = strcmp(directive(1), '+');
     elseif strcmp('ELLIPSIS', directive(2:end))
       tests(i).ellipsis = strcmp(directive(1), '+');
+    elseif strcmp('IGNORE_BLOCKS_WO_OUTPUT', directive(2:end))
+      tests(i).ignore_blocks_wo_output = strcmp(directive(1), '+');
     elseif strcmp('+SKIP', directive)
       tests(i).skip{end + 1} = 'true';
     elseif strcmp('+SKIP_IF', directive)
@@ -121,6 +124,9 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
   DOCTEST__result.skip = eval(DOCTEST__join_conditions(DOCTEST__result.skip));
   if DOCTEST__result.skip
      continue
+  end
+  if DOCTEST__result.ignore_blocks_wo_output && isempty(DOCTEST__result.want)
+    continue
   end
 
   % determine whether test is expected to fail

--- a/test/test_ignore_blocks_wo_output.texinfo
+++ b/test/test_ignore_blocks_wo_output.texinfo
@@ -1,0 +1,17 @@
+No output here, this code should be skipped:
+@example
+a = 5;          @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+assert(false);
+@end example
+
+@example
+  +-----------------+
+  |  ASCII ART ;-)  |      @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+  +-----------------+
+@end example
+
+@example
+a = 5;        @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+a = 6
+@result{} a = 6
+@end example

--- a/test/test_skip_wo_output.texinfo
+++ b/test/test_skip_wo_output.texinfo
@@ -16,3 +16,9 @@ a = 5;        @c doctest: +SKIP_BLOCKS_WO_OUTPUT
 a = 6
 @result{} a = 6
 @end example
+
+And check it was not skipped:
+@example
+a = 6
+@result{} a = 6
+@end example

--- a/test/test_skip_wo_output.texinfo
+++ b/test/test_skip_wo_output.texinfo
@@ -1,17 +1,17 @@
 No output here, this code should be skipped:
 @example
-a = 5;          @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+a = 5;          @c doctest: +SKIP_BLOCKS_WO_OUTPUT
 assert(false);
 @end example
 
 @example
   +-----------------+
-  |  ASCII ART ;-)  |      @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+  |  ASCII ART ;-)  |      @c doctest: +SKIP_BLOCKS_WO_OUTPUT
   +-----------------+
 @end example
 
 @example
-a = 5;        @c doctest: +IGNORE_BLOCKS_WO_OUTPUT
+a = 5;        @c doctest: +SKIP_BLOCKS_WO_OUTPUT
 a = 6
 @result{} a = 6
 @end example

--- a/test/test_skip_wo_output.texinfo
+++ b/test/test_skip_wo_output.texinfo
@@ -10,6 +10,7 @@ assert(false);
   +-----------------+
 @end example
 
+This one should not be skipped as it does have output
 @example
 a = 5;        @c doctest: +SKIP_BLOCKS_WO_OUTPUT
 a = 6

--- a/test/test_skip_wo_output_diary.m
+++ b/test/test_skip_wo_output_diary.m
@@ -10,3 +10,7 @@ function test_skip_wo_output_diary()
 % .. a = 6
 % a = 6
 %
+%
+% check that previous was not skipped
+% >> a
+% a = 6

--- a/test/test_skip_wo_output_diary.m
+++ b/test/test_skip_wo_output_diary.m
@@ -1,0 +1,12 @@
+function test_skip_wo_output_diary()
+%
+% No output here, so this code block should be skipped:
+% >> a = 5;          % doctest: +SKIP_BLOCKS_WO_OUTPUT
+% .. assert(false);
+%
+%
+% this one should still happen
+% >> a = 5;          % doctest: +SKIP_BLOCKS_WO_OUTPUT
+% .. a = 6
+% a = 6
+%


### PR DESCRIPTION
If this directive is on (`+IGNORE_BLOCKS_WO_OUTPUT`) and the
current example block (e.g., @example ... @end example) has no
expected output then we skip that block.

Adds a texinfo test.

Defaults to off for now.