### PR TITLE
indent with each subdir during traversal

### DIFF
--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -276,7 +276,7 @@ summary.num_tests_passed = 0;
 
 
 for i=1:numel(what)
-  summary = doctest_collect(what{i}, directives, summary, recursive, fid);
+  summary = doctest_collect(what{i}, directives, summary, recursive, 0, fid);
 end
 
 

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -60,7 +60,12 @@ end
 
 % Deal with directories
 if (strcmp(type, 'dir'))
-  if (~ strcmp(what, '.'))
+  if (strcmp(what, '.'))
+    if (depth == 0)
+      % cheap hack to not indent when calling "doctest ."
+      depth = -1;
+    end
+  else
     spaces = repmat(' ', 1, 2*depth);
     fprintf(fid, '%s%s%s\n', spaces, what, filesep());
   end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -67,7 +67,12 @@ if (strcmp(type, 'dir'))
     end
   else
     spaces = repmat(' ', 1, 2*depth);
-    fprintf(fid, '%s%s%s\n', spaces, what, filesep());
+    if (strcmp(what(end), filesep()))
+      slashchar = '';
+    else
+      slashchar = filesep();
+    end
+    fprintf(fid, '%s%s%s\n', spaces, what, slashchar);
   end
   oldcwd = chdir(what);
   files = dir('.');


### PR DESCRIPTION
This is on top of some other changes, just last couple commits...

current result for `doctest . recursive`:
````
Doctest v0.4.1-dev: this is Free Software without warranty, see source.

0.4.0/
inst/
  doctest.m ............................................ PASS   10/10  
src/
test/
  test_class ........................................... PASS    1/1   
  @test_class/test_class ............................... PASS    1/1   
  @test_class/test_method .............................. PASS    1/1   
  test_classdef ........................................ NO TESTS
  @test_classdef/amethod ............................... NO TESTS
  @test_classdef/test_classdef ......................... NO TESTS
  test_shadow .......................................... PASS    1/1   
  @test_shadow/test_shadow ............................. PASS    1/1   
  examples/
    greet.m ............................................ PASS    1/1   
  test_angle_brackets.m ................................ PASS    2/2   
  test_blank_match.m ................................... PASS    1/1   
  test_comments.texinfo ................................ PASS    3/3   
  test_compare_backspace.m ............................. PASS    1/1   
  test_compare_hyperlinks.m ............................ PASS    1/1   
  test_diary_style.texinfo ............................. PASS    6/6   
  test_diary_style_mixed.texinfo ....................... PASS    2/2   
  test_ellipsis.m ...................................... PASS    4/4   
  test_long_rows.m ..................................... PASS    1/1   
  test_long_rows.texinfo ............................... PASS    1/1   
  test_multi_result.texinfo ............................ PASS    9/9   
  test_multi_return.texinfo ............................ PASS    6/6   
  test_no_docs.m ....................................... NO TESTS
  test_pkg.m ........................................... PASS    2/2   
  test_shadow/
    test_in_shadow_dir.m ............................... PASS    3/3   
  test_shadow.m ........................................ PASS    2/2   
  test_skip.m .......................................... PASS    3/3   
  test_skip_comments.texinfo ........................... PASS    2/2   
  test_skip_if.m ....................................... PASS    4/4   
  test_skip_if_multiple.m .............................. PASS    5/5   
  test_skip_malformed.texinfo .......................... NO TESTS
  test_skip_only_one.m ................................. NO TESTS
  test_skip_unless.m ................................... PASS    4/4   
  test_var.texinfo ..................................... PASS    2/2   
  test_warning.m ....................................... PASS    1/1   
  test_whitespace.m .................................... PASS    8/8   
  test_xfail.m ......................................... PASS    3/3   
  test_xfail.texinfo ................................... PASS    1/1   
  test_xfail_if.m ...................................... PASS    6/6   
  test_xfail_if_multiple.m ............................. PASS    7/7   
  test_xfail_unless.m .................................. PASS    6/6   
tmp/
  doctest-matlab-0.4.0/
    doctest.m .......................................... PASS   10/10  
  doctest.m ............................................ PASS   10/10  

Summary:

   PASS  132/132 
````