### PR TITLE
Alternate name for license in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,4 +11,4 @@ Description: The Octave-Forge Doctest package finds specially-formatted
  during software development.
 Depends: octave (>= 4.0.0)
 Url: https://github.com/catch22/octave-doctest
-License: modified BSD
+License: BSD-3-Clause


### PR DESCRIPTION
*Not* a license change, just a renaming it.  This makes it match the
license name in .metainfo.xml.