### PR TITLE
Comments can robustly appear after directives

### DIFF
--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -48,11 +48,12 @@ for i=1:length(test_matches)
   tests(i).xfail = {};
 
   % find and process directives
-  re = ['(?:#|%)\s*doctest:\s+'      ... % e.g., "# doctest: "
-        '((?:\+|\-)\w+)'             ... % token for cmd, eg "+XSKIP_IF"
-        '(\s*\('                     ... % token for paren code, eg " (isfoo(7))"
-          '(?:(?!doctest:)(?!\n).)+' ... % any code, no \n, no "doctest:"
-        '\))?'];                         % end paren code
+  re = [ ...
+    '[#%]\s*doctest:\s+' ... % e.g., "# doctest: "
+    '([\+\-]\w+)'        ... % token for cmd, e.g., "+XSKIP_IF"
+    '(?:\s*\('           ... % open paren for code
+      '([^#%\n]+)'       ... % token for code, no newlines no comments
+    '\))?'];                 % close paren of code, at most one of these
   directive_matches = regexp(tests(i).source, re, 'tokens');
   for j = 1:length(directive_matches)
     directive = directive_matches{j}{1};

--- a/test/test_comments_with_directives.m
+++ b/test/test_comments_with_directives.m
@@ -1,0 +1,11 @@
+function test_comments_with_directives()
+% >> a = 6         %doctest: +XFAIL               % comment (with parenthetical)
+% b = 5
+%
+%
+% >> a = 7         % doctest: +XFAIL_IF (true)    % comment
+% b = 5
+%
+%
+% >> a = 8         % doctest: +XFAIL_IF (false)   % comment (with parenthetical)
+% a = 8


### PR DESCRIPTION
This fixes #144.  This also means we can simply the regexp so
probably fewer corner cases.  Downside is the conditional code
cannot contain the chars `#` or `%`: this is not anticipated to
cause much hardship.