### PR TITLE
Add "pseudodirectives" istexinfo/isdiary

### DIFF
--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -134,7 +134,8 @@ elseif strcmp(type, 'texinfo')
   target.name = what;
   target.link = '';
   target.depth = depth;
-  [target.docstring, target.error] = parse_texinfo(fileread(what));
+  [target.docstring, target.error, target.isdiary] = parse_texinfo(fileread(what));
+  target.istexinfo = true;
   targets = [target];
 else
   target = struct();
@@ -169,6 +170,9 @@ for i=1:numel(targets)
     continue;
   end
 
+  % non-configurable pseudo-directives: set based on the target
+  directives = doctest_default_directives(directives, 'IS_TEXINFO', target.istexinfo);
+  directives = doctest_default_directives(directives, 'IS_DIARY', target.isdiary);
   % run doctest
   results = doctest_run(target.docstring, directives);
 
@@ -224,7 +228,8 @@ function target = collect_targets_function(what)
   else
     target.link = sprintf('<a href="matlab:editorservices.openAndGoToLine(''%s'', 1);">%s</a>', which(what), what);
   end
-  [target.docstring, target.error] = extract_docstring(target.name);
+  [target.docstring, target.error, target.istexinfo, target.isdiary] = ...
+      extract_docstring(target.name);
 end
 
 
@@ -243,7 +248,8 @@ function targets = collect_targets_class(what, depth)
     target.link = sprintf('<a href="matlab:editorservices.openAndGoToLine(''%s'', 1);">%s</a>', which(what), what);
   end
   target.depth = depth;
-  [target.docstring, target.error] = extract_docstring(target.name);
+  [target.docstring, target.error, target.istexinfo, target.isdiary] = ...
+      extract_docstring(target.name);
   targets = target;
 
   % Next, add targets for all class methods
@@ -258,17 +264,21 @@ function targets = collect_targets_class(what, depth)
       target.link = sprintf('<a href="matlab:editorservices.openAndGoToFunction(''%s'', ''%s'');">%s</a>', which(what), meths{i}, target.name);
     end
     target.depth = depth;
-    [target.docstring, target.error] = extract_docstring(target.name);
+    [target.docstring, target.error, target.istexinfo, target.isdiary] = ...
+        extract_docstring(target.name);
     targets = [targets; target];
   end
 end
 
 
-function [docstring, error] = extract_docstring(name)
+function [docstring, error, istexinfo, isdiary] = extract_docstring(name)
+  istexinfo = false;
+  isdiary = true;
   if is_octave()
     [docstring, format] = get_help_text(name);
     if strcmp(format, 'texinfo')
-      [docstring, error] = parse_texinfo(docstring);
+      [docstring, error, isdiary] = parse_texinfo(docstring);
+      istexinfo = true;
     elseif strcmp(format, 'plain text')
       error = '';
     elseif strcmp(format, 'Not documented')
@@ -295,9 +305,11 @@ function [docstring, error] = extract_docstring(name)
 end
 
 
-function [docstring, error] = parse_texinfo(str)
+function [docstring, error, isdiary] = parse_texinfo(str)
   docstring = '';
   error = '';
+  % texinfo could have diary-style, and that might be useful to know
+  isdiary = false;
 
   % no example blocks? not an error, but nothing to do
   if (isempty(strfind(str, '@example')))
@@ -390,6 +402,7 @@ function [docstring, error] = parse_texinfo(str)
       L = strsplit (T{i}, '\n');
       L = regexprep (L, '^(\s*)(?:⇒|=>|⊣|-\|)', '$1', 'once', 'lineanchors');
       T{i} = strjoin (L, '\n');
+      isdiary = true;
       continue
     end
 

--- a/inst/private/doctest_default_directives.m
+++ b/inst/private/doctest_default_directives.m
@@ -8,6 +8,10 @@ function d = doctest_default_directives(varargin)
 
   defaults.normalize_whitespace = true;
   defaults.ellipsis = true;
+  % pseudo-directives: will be detected per target
+  defaults.is_texinfo = [];
+  defaults.is_diary = [];
+
 
   if (nargin == 0)
     d = defaults;
@@ -29,6 +33,10 @@ function d = doctest_default_directives(varargin)
       d.ellipsis = enable;
     case 'NORMALIZE_WHITESPACE'
       d.normalize_whitespace = enable;
+    case 'IS_TEXINFO'
+      d.is_texinfo = enable;
+    case 'IS_DIARY'
+      d.is_diary = enable;
     otherwise
       error('invalid directive "%s"', directive)
   end

--- a/inst/private/doctest_run.m
+++ b/inst/private/doctest_run.m
@@ -44,6 +44,8 @@ for i=1:length(test_matches)
   % set default options
   tests(i).normalize_whitespace = defaults.normalize_whitespace;
   tests(i).ellipsis = defaults.ellipsis;
+  tests(i).is_texinfo = defaults.is_texinfo;
+  tests(i).is_diary = defaults.is_diary;
   tests(i).skip = {};
   tests(i).xfail = {};
 


### PR DESCRIPTION
Each test records whether it came from texinfo or diary style (or both).  These are not currently used for anything, but potentially could be in the future (?)

I implemented this while trying to do the TEXINFO_SKIP_BLOCKS_WO_OUTPUT stuff (which ended up using another approach).

@catch22 potentially useful for anything you'd want to do?  Otherwise, I'll just drop it.
