### PR TITLE
Stop testing on Octave 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ language: generic
 
 matrix:
   include:
-    - env: OCT_PPA=no
+    - env: OCT_PPA=
       addons:
         apt:
           packages:
             - octave
             - liboctave-dev
-    - env: OCT_PPA=yes
+    - env: OCT_PPA=octave/octave-stable
+    - env: OCT_PPA=dac922/octave-unstable
 
 install:
   - export
-  - if [ "x$OCT_PPA" = "xyes" ]; then
-        sudo apt-add-repository -y ppa:octave/stable;
+  - if [ "x$OCT_PPA" != "x" ]; then
+        sudo apt-add-repository -y ppa:$OCT_PPA;
         sudo apt-get update -qq;
         sudo apt-get install -qq -y octave liboctave-dev;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,9 @@ dist: trusty
 # travis-ci does not have first-class support for octave
 language: generic
 
-matrix:
-  include:
-    - env: OCT_PPA=
-      addons:
-        apt:
-          packages:
-            - octave
-            - liboctave-dev
-    - env: OCT_PPA=octave/octave-stable
-    - env: OCT_PPA=dac922/octave-unstable
+env:
+- OCT_PPA=octave/octave-stable
+- OCT_PPA=dac922/octave-unstable
 
 install:
   - export

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 language: generic
 
 env:
-- OCT_PPA=octave/octave-stable
+- OCT_PPA=octave/stable
 - OCT_PPA=dac922/octave-unstable
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ language: generic
 
 env:
 - OCT_PPA=octave/stable
-- OCT_PPA=dac922/octave-unstable
+
+# not on trusty: http://ppa.launchpad.net/dac922/octave-unstable/ubuntu/pool/main/o/octave/
+#- OCT_PPA=dac922/octave-unstable
 
 install:
   - export


### PR DESCRIPTION
Some time ago we stopped supporting it, so drop from our CI tests.

@catch22 this ok with you?