### PR TITLE
refactor doctest_compare

### DIFF
--- a/inst/private/doctest_compare.m
+++ b/inst/private/doctest_compare.m
@@ -32,7 +32,8 @@ end
 
 want_re = regexptranslate('escape', want);
 if ellipsis
-  want_re = regexprep(want_re, '(\\\.){3}', '.*');
+  % replace "..." and any adjacent whitespace with ".*"
+  want_re = regexprep(want_re, '\s*(\\\.){3}\s*', '.*');
 end
 
 % allow "ans = " to be missing

--- a/test/test_ellipsis_match_empty.m
+++ b/test/test_ellipsis_match_empty.m
@@ -1,0 +1,20 @@
+function test_ellipsis_match_empty()
+% Ellipses should match empty string:
+% >> disp('abcdef')
+% abc...def
+%
+%
+% empty at ends:
+% >> disp('def')
+% ...def
+%
+% >> disp('def')
+% def...
+%
+%
+% Empty and whitespace:
+% >> disp('abc def')
+% abc ...def
+%
+% >> disp('abc def')
+% abc... def

--- a/test/test_ellipsis_match_whitespace.m
+++ b/test/test_ellipsis_match_whitespace.m
@@ -1,11 +1,4 @@
 function test_ellipsis_match_whitespace()
-% >> disp('    def')
-% ... def
-%
-% >> disp('def     ')
-% def ...
-%
-%
 % Whitespace in middle
 % >> disp('abc    def')
 % abc ... def
@@ -13,3 +6,31 @@ function test_ellipsis_match_whitespace()
 % abc ... def
 % >> disp('abc def')
 % abc...def
+%
+%
+% Should fail: expects something surrounded by whitespace
+% >> disp('abc def')   % doctest: +XFAIL
+% abc ... def
+%
+%
+% This is ok, because there are two whitespaces in input
+% >> disp('abc  def')
+% abc ... def
+%
+%
+% Currently, ellipses will match empty the string but we trim begin/end of
+% lines, so these probably fail because there is nothing to match the space
+% after/before the "...".  Probably ok to change this behaviour.
+% >> disp('    def')   % doctest: +XFAIL
+% ... def
+%
+% >> disp('def    ')   % doctest: +XFAIL
+% def ...
+%
+%
+% However, these are ok:
+% >> disp('def')
+% ...def
+%
+% >> disp('def')
+% def...

--- a/test/test_ellipsis_match_whitespace.m
+++ b/test/test_ellipsis_match_whitespace.m
@@ -1,0 +1,15 @@
+function test_ellipsis_match_whitespace()
+% >> disp('    def')
+% ... def
+%
+% >> disp('def     ')
+% def ...
+%
+%
+% Whitespace in middle
+% >> disp('abc    def')
+% abc ... def
+% >> disp('abc  def')
+% abc ... def
+% >> disp('abc def')
+% abc...def


### PR DESCRIPTION
This is on top of a few other things, but the important commit is:

```
    rework "compare" to avoid changing both strings

Instead, try to make a regular expression from "WANT" and then
match that against "GOT".  Before, we did a bit of both so this
should be more maintainable.
```

This makes slight changes to the behaviour of `...`.  I think it also fixes #153.  Although slight changes to the tests I did there...
