### PR TITLE
Support "clear"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 doctest 0.5.1-dev
 =================
 
+  * Tests can now call "clear" and "clear all".
+
+  * Fix for running on Octave development versions (upcoming 4.4.0).
+
 
 
 doctest 0.5.0 (2016-11-13)

--- a/inst/private/doctest_datastore.m
+++ b/inst/private/doctest_datastore.m
@@ -1,0 +1,38 @@
+%DOCTEST_DATASTORE - used internally by doctest
+%
+% Usage:
+%   doctest_datastore(action, arg)
+%       Store variables in a way that survives "clear" and "clear all".
+%
+% See https://gcurrentub.com/catch22/octave-doctest/issues/149 for discussion.
+function out = doctest_datastore(action, arg)
+
+mlock();
+persistent i tests;
+
+switch lower(action)
+  case 'clear_and_munlock'
+    % don't leave persistent data lying around
+    tests = [];
+    i = [];
+
+    % unlock so that changes to .m file are picked up again
+    munlock();
+
+  case 'set_tests'
+    tests = num2cell(arg); % cell array so it can be heterogeneous
+  case 'get_tests'
+    out = tests;
+
+  case 'set_current_index'
+    i = arg;
+  case 'set_current_test'
+    tests{i} = arg;
+  case 'get_current_test'
+    out = tests{i};
+
+  otherwise
+    error('unexpected action "%s"', action);
+end
+
+end

--- a/inst/private/doctest_format_exception.m
+++ b/inst/private/doctest_format_exception.m
@@ -1,0 +1,25 @@
+function formatted = doctest_format_exception(ex)
+%DOCTEST_FORMAT_EXCEPTION - used internally by doctest
+%
+% Usage:
+%   doctest_format_exception(ex)
+%       Given an exception, return error message to be reported.
+%
+
+% octave?
+if is_octave()
+  formatted = ['??? ' ex.message];
+  return
+end
+
+% matlab!
+if strcmp(ex.stack(1).name, 'doctest_run_tests')
+  % we don't want the report, we just want the message
+  % otherwise it'll talk about evalc, which is not what the user got on
+  % the command line.
+  formatted = ['??? ' ex.message];
+else
+  formatted = ['??? ' ex.getReport('basic')];
+end
+
+end

--- a/inst/private/doctest_join_conditions.m
+++ b/inst/private/doctest_join_conditions.m
@@ -1,0 +1,16 @@
+function result = doctest_join_conditions(conditions)
+%DOCTEST_JOIN_CONDITIONS - used internally by doctest
+%
+% Usage:
+%   doctest_join_conditions(conditions)
+%       Given a cell array of conditions (represented as strings to be eval'ed),
+%       return the string that corresponds to their logical "or".
+%
+
+if isempty(conditions)
+  result = 'false';
+else
+  result = strcat('(', strjoin(conditions, ') || ('), ')');
+end
+
+end

--- a/inst/private/doctest_run_docstring.m
+++ b/inst/private/doctest_run_docstring.m
@@ -2,7 +2,7 @@ function results = doctest_run_docstring(docstring, defaults)
 %DOCTEST_RUN_DOCSTRING - used internally by doctest
 %
 % Usage:
-%   doctest_run_docstring(docstring)
+%   doctest_run_docstring(docstring, defaults)
 %       Extract all the examples in the input docstring into a
 %       structure.  Process various flags and directives that
 %       about each test.  Run the tests in a common namespace.

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -15,21 +15,23 @@ function DOCTEST__results = doctest_run_tests(DOCTEST__tests)
 % The return value is documented in "doctest_run_docstring".
 
 % Implementation note: all internal variables should start with
-% "DOCTEST__" as these will be available to the tests.
+% "DOCTEST__" as (1) these will necessarily be exposed to the tests
+% and (2) should not overwrite variables used by ongoing tests.
 
 % do not split long rows (TODO: how to do this on MATLAB?)
 if is_octave()
   split_long_rows(0, 'local');
 end
 
-% initialize data store
-mlock();
-DOCTEST__datastore('set_all', DOCTEST__tests);
+% initialize data store (used to preserve state across iterations
+% in the presence of "clear" and "clear all"s in tests)
+doctest_datastore('set_tests', DOCTEST__tests);
 
 for DOCTEST__i = 1:numel(DOCTEST__tests)
-  %DOCTEST__result = DOCTEST__tests(DOCTEST__i);
-  DOCTEST__datastore('init_i', DOCTEST__i);
-  DOCTEST__result = DOCTEST__datastore('get_ith');
+  % from the second iteration on, the only local variable that we can
+  % rely on being present is DOCTEST__i
+  doctest_datastore('set_current_index', DOCTEST__i);
+  DOCTEST__current_test = doctest_datastore('get_current_test');
 
   % define test-global constants (these are accessible by the tests)
   DOCTEST_OCTAVE = is_octave();
@@ -37,106 +39,53 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
 
   % determine whether test should be skipped
   % (careful about Octave bug #46397 to not change the current value of “ans”)
-  eval (strcat ('DOCTEST__result.skip = ', ...
-                 DOCTEST__join_conditions (DOCTEST__result.skip), ...
+  eval (strcat ('DOCTEST__current_test.skip = ', ...
+                 doctest_join_conditions(DOCTEST__current_test.skip), ...
                 ';'));
-  if (DOCTEST__result.skip)
-     DOCTEST__datastore('set_ith', DOCTEST__result);
+  if (DOCTEST__current_test.skip)
+     doctest_datastore('set_current_test', DOCTEST__current_test);
      continue
   end
 
   % determine whether test is expected to fail
   % (careful about Octave bug #46397 to not change the current value of “ans”)
-  eval (strcat ('DOCTEST__result.xfail = ', ...
-                 DOCTEST__join_conditions (DOCTEST__result.xfail), ...
+  eval (strcat ('DOCTEST__current_test.xfail = ', ...
+                 doctest_join_conditions(DOCTEST__current_test.xfail), ...
                 ';'));
-  DOCTEST__datastore('set_ith', DOCTEST__result);
+  doctest_datastore('set_current_test', DOCTEST__current_test);
 
+  % run the test code
   try
-    DOCTEST__got = evalc(DOCTEST__result.source);
+    DOCTEST__got = evalc(DOCTEST__current_test.source);
   catch DOCTEST__exception
-    DOCTEST__got = DOCTEST__format_exception(DOCTEST__exception);
+    DOCTEST__got = doctest_format_exception(DOCTEST__exception);
   end
-  
-  % pull from datastore (in case test did "clear")
-  DOCTEST__result = DOCTEST__datastore('get_ith');
-  DOCTEST__result.got = DOCTEST__got;
+
+  % at this point, we can only rely on the DOCTEST__got variable
+  % being available
+  DOCTEST__current_test = doctest_datastore('get_current_test');
+  DOCTEST__current_test.got = DOCTEST__got;
 
   % determine if test has passed
-  DOCTEST__result.passed = doctest_compare(DOCTEST__result.want, DOCTEST__result.got, DOCTEST__result.normalize_whitespace, DOCTEST__result.ellipsis);
-  if DOCTEST__result.xfail
-    DOCTEST__result.passed = ~DOCTEST__result.passed;
+  DOCTEST__current_test.passed = doctest_compare(DOCTEST__current_test.want, DOCTEST__current_test.got, DOCTEST__current_test.normalize_whitespace, DOCTEST__current_test.ellipsis);
+  if DOCTEST__current_test.xfail
+    DOCTEST__current_test.passed = ~DOCTEST__current_test.passed;
   end
 
-  %DOCTEST__results = [DOCTEST__results; DOCTEST__result];
-  DOCTEST__datastore('set_ith', DOCTEST__result);
+  doctest_datastore('set_current_test', DOCTEST__current_test);
 end
 
-DOCTEST__results = DOCTEST__datastore('get_all');
-DOCTEST__datastore('clear');
-munlock();
-end
+% retrieve all tests from data store
+tests = doctest_datastore('get_tests');
+doctest_datastore('clear_and_munlock');
 
-
-function out = DOCTEST__datastore(action, var)
-  % store variables in a way that survives "clear" and "clear all".
-
-  % try to survive a test doing "clear" and "clear all"
-  % https://github.com/catch22/octave-doctest/issues/149
-  persistent i results
-
-  switch lower(action)
-    case 'clear'
-      % don't leave mlocked persistent data lying around
-      results = [];
-      i = [];
-    case 'set_all'
-      % cell array so it can be heterogeneous
-      results = num2cell(var);
-    case 'init_i'
-      i = var;
-    case 'set_ith'
-      results{i} = var;
-    case 'get_ith'
-      out = results{i};
-    case 'get_all'
-      % unwrap from cell-array, discarding skips
-      %out = cell2mat(results);  % fails b/c they have different fields
-      out = [];
-      for j=1:numel(results)
-        if (~ any(results{j}.skip))
-          out = [out results{j}];
-        end
-      end
-    otherwise
-      error ('unexpected action')
+% unwrap from cell-array, discarding skips
+%DOCTEST__results = cell2mat(tests);  % fails b/c they have different fields
+DOCTEST__results = [];
+for j=1:numel(tests)
+  if ~any(tests{j}.skip)
+    DOCTEST__results = [DOCTEST__results tests{j}];
   end
 end
 
-
-function formatted = DOCTEST__format_exception(ex)
-  if is_octave()
-    formatted = ['??? ' ex.message];
-    return
-  end
-
-  if strcmp(ex.stack(1).name, 'doctest_run_tests')
-    % we don't want the report, we just want the message
-    % otherwise it'll talk about evalc, which is not what the user got on
-    % the command line.
-    formatted = ['??? ' ex.message];
-  else
-    formatted = ['??? ' ex.getReport('basic')];
-  end
-end
-
-
-% given a cell array of conditions (represented as strings to be eval'ed),
-% return the string that corresponds to their logical "or".
-function result = DOCTEST__join_conditions(conditions)
-  if isempty(conditions)
-    result = 'false';
-  else
-    result = strcat('(', strjoin(conditions, ') || ('), ')');
-  end
 end

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -14,27 +14,21 @@ function DOCTEST__results = doctest_run_tests(DOCTEST__tests)
 %
 % The return value is documented in "doctest_run_docstring".
 
-% Implementation note: all variables should start with
+% Implementation note: all internal variables should start with
 % "DOCTEST__" as these will be available to the tests.
-
-  % Call subfcns at least once, workaround for test doing early "clear all"
-  DOCTEST__join_conditions([]);
-  try
-    error('meh')
-  catch ex
-  end
-  DOCTEST__format_exception(ex);
 
 % do not split long rows (TODO: how to do this on MATLAB?)
 if is_octave()
-  split_long_rows(0, 'local')
+  split_long_rows(0, 'local');
 end
 
-DOCTEST__datastore('set_all', DOCTEST__tests)
+% initialize data store
+mlock();
+DOCTEST__datastore('set_all', DOCTEST__tests);
 
 for DOCTEST__i = 1:numel(DOCTEST__tests)
   %DOCTEST__result = DOCTEST__tests(DOCTEST__i);
-  DOCTEST__datastore('init_i', DOCTEST__i)
+  DOCTEST__datastore('init_i', DOCTEST__i);
   DOCTEST__result = DOCTEST__datastore('get_ith');
 
   % define test-global constants (these are accessible by the tests)
@@ -63,6 +57,7 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
   catch DOCTEST__exception
     DOCTEST__got = DOCTEST__format_exception(DOCTEST__exception);
   end
+  
   % pull from datastore (in case test did "clear")
   DOCTEST__result = DOCTEST__datastore('get_ith');
   DOCTEST__result.got = DOCTEST__got;
@@ -79,6 +74,7 @@ end
 
 DOCTEST__results = DOCTEST__datastore('get_all');
 DOCTEST__datastore('clear');
+munlock();
 end
 
 
@@ -87,7 +83,6 @@ function out = DOCTEST__datastore(action, var)
 
   % try to survive a test doing "clear" and "clear all"
   % https://github.com/catch22/octave-doctest/issues/149
-  mlock()
   persistent i results
 
   switch lower(action)
@@ -120,8 +115,6 @@ end
 
 
 function formatted = DOCTEST__format_exception(ex)
-  mlock()  % not clear why we need this
-
   if is_octave()
     formatted = ['??? ' ex.message];
     return
@@ -141,7 +134,6 @@ end
 % given a cell array of conditions (represented as strings to be eval'ed),
 % return the string that corresponds to their logical "or".
 function result = DOCTEST__join_conditions(conditions)
-  mlock()  % not clear why we need this
   if isempty(conditions)
     result = 'false';
   else

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -17,6 +17,14 @@ function DOCTEST__results = doctest_run_tests(DOCTEST__tests)
 % Implementation note: all variables should start with
 % "DOCTEST__" as these will be available to the tests.
 
+  % Call subfcns at least once, workaround for test doing early "clear all"
+  DOCTEST__join_conditions([]);
+  try
+    error('meh')
+  catch ex
+  end
+  DOCTEST__format_exception(ex);
+
 % do not split long rows (TODO: how to do this on MATLAB?)
 if is_octave()
   split_long_rows(0, 'local')

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -24,14 +24,14 @@ end
 
 DOCTEST__datastore('set_all', DOCTEST__tests)
 
-% define test-global constants (these are accessible by the tests)
-DOCTEST_OCTAVE = is_octave();
-DOCTEST_MATLAB = ~DOCTEST_OCTAVE;
-
 for DOCTEST__i = 1:numel(DOCTEST__tests)
   %DOCTEST__result = DOCTEST__tests(DOCTEST__i);
   DOCTEST__datastore('init_i', DOCTEST__i)
   DOCTEST__result = DOCTEST__datastore('get_ith');
+
+  % define test-global constants (these are accessible by the tests)
+  DOCTEST_OCTAVE = is_octave();
+  DOCTEST_MATLAB = ~DOCTEST_OCTAVE;
 
   % determine whether test should be skipped
   % (careful about Octave bug #46397 to not change the current value of “ans”)

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -22,13 +22,16 @@ if is_octave()
   split_long_rows(0, 'local')
 end
 
+DOCTEST__datastore('set_all', DOCTEST__tests)
+
 % define test-global constants (these are accessible by the tests)
 DOCTEST_OCTAVE = is_octave();
 DOCTEST_MATLAB = ~DOCTEST_OCTAVE;
 
-DOCTEST__results = [];
 for DOCTEST__i = 1:numel(DOCTEST__tests)
-  DOCTEST__result = DOCTEST__tests(DOCTEST__i);
+  %DOCTEST__result = DOCTEST__tests(DOCTEST__i);
+  DOCTEST__datastore('init_i', DOCTEST__i)
+  DOCTEST__result = DOCTEST__datastore('get_ith');
 
   % determine whether test should be skipped
   % (careful about Octave bug #46397 to not change the current value of “ans”)
@@ -36,6 +39,7 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
                  DOCTEST__join_conditions (DOCTEST__result.skip), ...
                 ';'));
   if (DOCTEST__result.skip)
+     DOCTEST__datastore('set_ith', DOCTEST__result);
      continue
   end
 
@@ -44,13 +48,16 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
   eval (strcat ('DOCTEST__result.xfail = ', ...
                  DOCTEST__join_conditions (DOCTEST__result.xfail), ...
                 ';'));
+  DOCTEST__datastore('set_ith', DOCTEST__result);
 
-  % evaluate input (structure adapted from a StackOverflow answer by user Amro, see http://stackoverflow.com/questions/3283586 and http://stackoverflow.com/users/97160/amro)
   try
-    DOCTEST__result.got = evalc(DOCTEST__result.source);
+    DOCTEST__got = evalc(DOCTEST__result.source);
   catch DOCTEST__exception
-    DOCTEST__result.got = DOCTEST__format_exception(DOCTEST__exception);
+    DOCTEST__got = DOCTEST__format_exception(DOCTEST__exception);
   end
+  % pull from datastore (in case test did "clear")
+  DOCTEST__result = DOCTEST__datastore('get_ith');
+  DOCTEST__result.got = DOCTEST__got;
 
   % determine if test has passed
   DOCTEST__result.passed = doctest_compare(DOCTEST__result.want, DOCTEST__result.got, DOCTEST__result.normalize_whitespace, DOCTEST__result.ellipsis);
@@ -58,13 +65,54 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
     DOCTEST__result.passed = ~DOCTEST__result.passed;
   end
 
-  DOCTEST__results = [DOCTEST__results; DOCTEST__result];
+  %DOCTEST__results = [DOCTEST__results; DOCTEST__result];
+  DOCTEST__datastore('set_ith', DOCTEST__result);
 end
 
+DOCTEST__results = DOCTEST__datastore('get_all');
+DOCTEST__datastore('clear');
+end
+
+
+function out = DOCTEST__datastore(action, var)
+  % store variables in a way that survives "clear" and "clear all".
+
+  % try to survive a test doing "clear" and "clear all"
+  % https://github.com/catch22/octave-doctest/issues/149
+  mlock()
+  persistent i results
+
+  switch lower(action)
+    case 'clear'
+      % don't leave mlocked persistent data lying around
+      results = [];
+      i = [];
+    case 'set_all'
+      % cell array so it can be heterogeneous
+      results = num2cell(var);
+    case 'init_i'
+      i = var;
+    case 'set_ith'
+      results{i} = var;
+    case 'get_ith'
+      out = results{i};
+    case 'get_all'
+      % unwrap from cell-array, discarding skips
+      %out = cell2mat(results);  % fails b/c they have different fields
+      out = [];
+      for j=1:numel(results)
+        if (~ any(results{j}.skip))
+          out = [out results{j}];
+        end
+      end
+    otherwise
+      error ('unexpected action')
+  end
 end
 
 
 function formatted = DOCTEST__format_exception(ex)
+  mlock()  % not clear why we need this
 
   if is_octave()
     formatted = ['??? ' ex.message];
@@ -85,6 +133,7 @@ end
 % given a cell array of conditions (represented as strings to be eval'ed),
 % return the string that corresponds to their logical "or".
 function result = DOCTEST__join_conditions(conditions)
+  mlock()  % not clear why we need this
   if isempty(conditions)
     result = 'false';
   else

--- a/test/test_clear.m
+++ b/test/test_clear.m
@@ -1,0 +1,27 @@
+function test_clear()
+% Easy things first, clearing one variable
+% >> a = 6;
+% >> b = 7;
+% >> clear a
+% >> b
+% b =  7
+%
+%
+% Harder:
+% >> clear
+% >> a
+% ??? ...ndefined ...
+%
+%
+% >> a = 4
+% a = 4
+%
+%
+% "clear all" clears stuff inside persistent vars
+% >> clear all
+% >> a
+% ??? ...ndefined ...
+%
+%
+% >> a = 5
+% a = 5

--- a/test/test_clear.m
+++ b/test/test_clear.m
@@ -5,6 +5,8 @@ function test_clear()
 % >> clear a
 % >> b
 % b =  7
+% >> a
+% ??? ...ndefined ...
 %
 %
 % Harder:

--- a/test/test_clear_all_first.m
+++ b/test/test_clear_all_first.m
@@ -1,0 +1,10 @@
+function test_clear_all_first()
+% If we "clear all" very early, our implementation may break if
+% subfunctions haven't yet been called.  At least on Octave 4.2.1.
+% >> clear all
+% >> a
+% ??? ...ndefined ...
+%
+%
+% >> a = 6
+% a =  6

--- a/test/test_clear_isoctave.m
+++ b/test/test_clear_isoctave.m
@@ -1,0 +1,19 @@
+function test_clear_isoctave()
+% Easy things first, clearing one variable
+% >> a = 6
+% a =  6
+%
+%
+% >> clear
+% >> a
+% ??? ...ndefined ...
+%
+%
+% >> clear all
+% >> a
+% ??? ...ndefined ...
+%
+%
+% Make sure these macros are still available after a clear
+% >> a = 42   % doctest: +XFAIL_IF(DOCTEST_OCTAVE | DOCTEST_MATLAB)
+% a =  0


### PR DESCRIPTION
Fixes #149.  @catch22 what do you think?

There is a bit of complexity coming from `DOCTEST__results` and `DOCTEST__tests` being slightly different (b/c of skipped tests).  I'm thinking of refactoring a bit to make the input a cell array of tests (instead of a struct array).  But for now, this maintains the status quo.

Bikeshedding this "datastore" object and its "methods" is certainly welcome!