### PR TITLE
Temporary workaround for "help myclass" breaking method tests

### DIFF
--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -239,6 +239,19 @@ function targets = collect_targets_class(what, depth)
     % Octave methods('@foo') gives java error, Matlab just says "No methods"
     what = what(2:end);
   end
+
+  % TODO: workaround github.com/catch22/octave-doctest/issues/135 by
+  % accessing all non-constructor method help text *before* "help obj"
+  if (is_octave ())
+    meths = methods (what);
+    for i=1:numel (meths)
+      if (~ strcmp (meths{i}, what))  % skip @obj/obj
+        name = sprintf ('@%s%s%s', what, filesep (), meths{i});
+        [docstring, format] = get_help_text (name);
+      end
+    end
+  end  % end workaround
+
   % First, "help class".  For classdef, this differs from "help class.class"
   % (general class help vs constructor help).  For old-style classes we will
   % probably end up testing the constructor twice but... meh.


### PR DESCRIPTION
Due to an upstream bug https://savannah.gnu.org/bugs/index.php?48041
if "help myclass" or `help @myclass/myclass` is called on a classdef
class, then "help myclass/mymethod" won't work during that session.

So we make an extra loop over the class, accessing the help text for
each non-constructor method.  Octave then seems to cache this text
(or something) and the tests work.

Performance: this workaround adds a very small overhead (0.3s on
Symbolic's large `@sym` class), compared to the cost of extracting
all the tests (many seconds on same example).  Nonetheless, it
should be removed once the upstream bug is fixed.

Fixes #135.  Well, workaround anyway.