### PR TITLE
Find tests in .oct files

### DIFF
--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -1,6 +1,6 @@
 %% Copyright (c) 2010 Thomas Grenfell Smith
 %% Copyright (c) 2011, 2013-2016 Michael Walter
-%% Copyright (c) 2015-2017 Colin B. Macdonald
+%% Copyright (c) 2015-2019 Colin B. Macdonald
 %%
 %% Redistribution and use in source and binary forms, with or without
 %% modification, are permitted provided that the following conditions are met:
@@ -41,6 +41,7 @@
 %% @item function;
 %% @item class;
 %% @item Texinfo file;
+%% @item .oct/.mex compiled code;
 %% @item directory/folder (pass @code{-nonrecursive} to skip subfolders);
 %% @item cell array of such items.
 %% @end itemize

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -24,6 +24,9 @@ if is_octave()
   [~, ~, ext] = fileparts(what);
   if any(strcmpi(ext, {'.texinfo' '.texi' '.txi' '.tex'}))
     type = 'texinfo';
+  elseif (exist (what) == 3)  % .oct/.mex
+    [~, what, ~] = fileparts (what);  % strip extension if present
+    type = 'function';                % then access like any function
   elseif (exist(what, 'file') && ~exist(what, 'dir')) || exist(what, 'builtin');
     if (exist(['@' what], 'dir'))
       % special case, e.g., @logical is class, logical is builtin
@@ -109,7 +112,8 @@ if (strcmp(type, 'dir'))
       end
     else
       [~, ~, ext] = fileparts(f);
-      if (~ any(strcmpi(ext, {'.m' '.texinfo' '.texi' '.txi' '.tex'})))
+      if (~ any(strcmpi(ext, ...
+                {'.m' '.texinfo' '.texi' '.txi' '.tex' '.oct' '.mex'})))
         %fprintf(fid, 'Debug: ignoring file "%s"\n', f)
         continue
       end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -10,7 +10,7 @@ function summary = doctest_collect(what, directives, summary, recursive, depth, 
 %%
 % Copyright (c) 2010 Thomas Grenfell Smith
 % Copyright (c) 2015 Michael Walter
-% Copyright (c) 2015-2017 Colin B. Macdonald
+% Copyright (c) 2015-2018 Colin B. Macdonald
 % Copyright (c) 2015 Oliver Heimlich
 % This is Free Software, BSD-3-Clause, see doctest.m for details.
 


### PR DESCRIPTION
"help meh.oct" doesn't work so strip the ".oct" if specified.  This
makes `doctest .` work.  If both meh.oct and meh.m are present,
"help meh" will get the .oct file; this does the same.  `doctest meh.m`
will explicitly test the .m file.  This may work for mex files although
I haven't tested that.