### PR TITLE
[wip] autoload .oct file functions

### DIFF
--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -26,7 +26,7 @@ if is_octave()
     type = 'texinfo';
   elseif (exist (what) == 3)  % .oct/.mex
     [~, what, ~] = fileparts (what);  % strip extension if present
-    type = 'function';                % then access like any function
+    type = 'octfile';                 % then access like any function
   elseif (exist(what, 'file') && ~exist(what, 'dir')) || exist(what, 'builtin');
     if (exist(['@' what], 'dir'))
       % special case, e.g., @logical is class, logical is builtin
@@ -124,6 +124,19 @@ if (strcmp(type, 'dir'))
   return
 end
 
+
+% Deal with .oct files, which may define more than one function
+if (strcmp(type, 'octfile'))
+  len = numel (what) + 4;
+  list = autoload ();
+  pmatch = @(e) (numel (e.file) > len) && strcmp (e.file(end-len+1:end), [what '.oct']);
+  idx = find (arrayfun (pmatch, list));
+  for i = 1:numel (idx)
+    name = list(idx(i)).function;
+    summary = doctest_collect (name, directives, summary, recursive, depth, fid);
+  end
+  type = 'function';
+end
 
 
 % Build structure array with the following fields:


### PR DESCRIPTION
@cbm755 something like this, works for me with all of my test cases.

Side effect being, if you `doctest specific_function`, and that function is also the name of a .oct file, it will also test all the other functions in the .oct file.