### PR TITLE
adjust test for "format long" changes

### DIFF
--- a/test/test_format.m
+++ b/test/test_format.m
@@ -5,8 +5,8 @@
 %
 % If tests change it...
 % >> format long
-% >> b = 1/6
-% b = 0.166666666...7
+% >> b = 10/6
+% b = 1.66666666...7
 %
 %
 % ... they should change it back to defaults


### PR DESCRIPTION
`format long` behaves differently sometime between 4.2 and 5.1 for numbers
less than 1 (such as 1/6 used in this test).
Adjust the test to 10/6 instead, which gives same result.  Tested on 4.2,
5.0.91, 6.0, and Matlab.