### PR TITLE
use "+" postfix for developement version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Name: doctest
-Version: 0.6.1
+Version: 0.6.1+
 Date: 2018-01-04
 Author: various authors
 Maintainer: Colin B. Macdonald <cbm@m.fsf.org>, Michael Walter <michael.walter@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-doctest 0.7.0-dev
-=================
+doctest 0.6.1+
+==============
 
   * Functions within compiled `.oct` files can now be tested.
 

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -299,7 +299,7 @@ fid = 1;
 [color_ok, color_err, color_warn, reset] = doctest_colors(fid);
 
 % print banner
-fprintf(fid, 'Doctest v0.7.0-dev: this is Free Software without warranty, see source.\n\n');
+fprintf(fid, 'Doctest v0.6.1+: this is Free Software without warranty, see source.\n\n');
 
 
 summary = struct();


### PR DESCRIPTION
Rational documented at [1].

[1] https://savannah.gnu.org/bugs/?55829