### PR TITLE
Convert CI to Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ services:
 
 matrix:
   include:
-  - name: "Octave latest release"
-    env: TAG=latest
+  - name: "Octave version 4.2"
+    env: TAG=4.2
+  - name: "Octave version 4.4"
+    env: TAG=4.4
+  - name: "Octave version 5"
+    env: TAG=5
 
 before_install:
 - docker pull mtmiller/octave:${TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ dist: xenial
 language: generic
 
 services:
-  - docker
+- docker
 
 matrix:
   include:
   - name: "Octave latest release"
-    env: IMAGE_TAG=latest
+    env: TAG=latest
 
 before_install:
-  - docker pull mtmiller/octave:${IMAGE_TAG}
+- docker pull mtmiller/octave:${TAG}
 
 script:
-  - docker run --volume=${PWD}:/doctest mtmiller/octave:${IMAGE_TAG} make -C /doctest test test-interactive test-bist
+- docker run --volume=${PWD}:/doctest:z mtmiller/octave:${TAG} make -C /doctest test test-interactive test-bist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,16 @@
-sudo: required
-dist: trusty
-
-# Notes:
-#   * 2019-02: trusty: distro Octave is 3.8
-#   * 2019-02: xenial: snapshots don't work, distro Octave is 4.0
-
-# travis-ci does not have first-class support for octave
+dist: xenial
 language: generic
+
+services:
+  - docker
 
 matrix:
   include:
-    #- env: OCT=distro
-    #  addons:
-    #    apt:
-    #      packages:
-    #      - octave
-    - env: OCT=ppa
-      addons:
-        apt:
-          sources:
-          - sourceline: 'ppa:octave/stable'
-          packages:
-          - octave
-    - env: OCT=daily
-      addons:
-        apt:
-          packages:
-          - octave
-  allow_failures:
-    - env: OCT=daily
-      addons:
-        apt:
-          packages:
-          - octave
-
+  - name: "Octave latest release"
+    env: IMAGE_TAG=latest
 
 before_install:
-  - if [ "x$OCT" = "xdaily" ]; then
-        wget https://s3.amazonaws.com/octave-snapshot/public/octave-ubuntu-trusty-snapshot.tar.xz;
-        sudo tar --extract --directory=/usr/local --strip-components=1 --file=octave-ubuntu-trusty-snapshot.tar.xz;
-    fi
+  - docker pull mtmiller/octave:${IMAGE_TAG}
 
-script: make test test-interactive
+script:
+  - docker run --volume=${PWD}:/doctest mtmiller/octave:${IMAGE_TAG} make -C /doctest test test-interactive

--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ clean:
 	rm -rf "${BUILD_DIR}"
 
 test:
-	${OCTAVE} --path ${PWD}/inst --eval "${TEST_CODE}"
+	${OCTAVE} --path ${CURDIR}/inst --eval "${TEST_CODE}"
 
 test-interactive:
-	script --quiet --command "${OCTAVE} --path ${PWD}/inst --eval \"${TEST_CODE}\"" /dev/null
+	script --quiet --command "${OCTAVE} --path ${CURDIR}/inst --eval \"${TEST_CODE}\"" /dev/null
 
 
 ## Install in Octave (locally)
@@ -120,7 +120,7 @@ ${INSTALLED_PACKAGE}: ${OCTAVE_RELEASE_TARBALL}
 matlab_pkg: $(MATLAB_PKG_ZIP)
 
 ${MATLAB_PKG}: | $(BUILD_DIR) ${MATLAB_PKG}/private
-	$(OCTAVE) --path ${PWD}/util --silent --eval \
+	$(OCTAVE) --path ${CURDIR}/util --silent --eval \
 		"convert_comments('inst/', '', '../${MATLAB_PKG}/')"
 	cp -ra inst/private/*.m ${MATLAB_PKG}/private/
 	cp -ra COPYING ${MATLAB_PKG}/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ MATLAB ?= matlab
 
 TEST_CODE=ver(), success = doctest({'doctest', 'test/', 'test/examples/'}); exit(~success);
 # run tests twice so we can see some output
-BIST_CODE=cd('test'); test('bist'); success = test('bist'); exit(~success);
+BIST_CODE=cd('test'); pwd(), test('bist'); success = test('bist'); exit(~success);
 
 
 .PHONY: help clean install test test-interactive dist html matlab_test matlab_pkg
@@ -113,7 +113,7 @@ test-interactive:
 	script --quiet --command "${OCTAVE} --path ${CURDIR}/inst --eval \"${TEST_CODE}\"" /dev/null
 
 test-bist:
-	${OCTAVE} --path ${PWD}/inst --eval "${BIST_CODE}"
+	${OCTAVE} --path ${CURDIR}/inst --eval "${BIST_CODE}"
 
 ## Install in Octave (locally)
 install: ${INSTALLED_PACKAGE}


### PR DESCRIPTION
Convert Travis CI to run all tests in the `mtmiller/octave` Docker image instead of the native Travis Ubuntu environment.

Addresses #204