### PR TITLE
trim blank whitespace from around error messages

### DIFF
--- a/inst/private/doctest_format_exception.m
+++ b/inst/private/doctest_format_exception.m
@@ -7,14 +7,14 @@ function formatted = doctest_format_exception(ex)
 
 %%
 % Copyright (c) 2010 Thomas Grenfell Smith
-% Copyright (c) 2015 Colin B. Macdonald
+% Copyright (c) 2015, 2019 Colin B. Macdonald
 % Copyright (c) 2015, 2017 Michael Walter
 % This is Free Software, BSD-3-Clause, see doctest.m for details.
 
 
 % octave?
 if is_octave()
-  formatted = ['??? ' ex.message];
+  formatted = ['??? ' strtrim(ex.message)];
   return
 end
 


### PR DESCRIPTION
This should be harmless and will look a little better if there are
say blank lines at then end of an error message.