### PR TITLE
Detect and use GNU tar (so it works on BSD systems)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ SHELL   := /bin/bash
 ## notice and this notice are preserved.  This file is offered as-is,
 ## without any warranty.
 
+TAR := $(shell which gtar 2>/dev/null || echo tar)
+
 PACKAGE := $(shell grep "^Name: " DESCRIPTION | cut -f2 -d" ")
 VERSION := $(shell grep "^Version: " DESCRIPTION | cut -f2 -d" ")
 
@@ -55,7 +57,7 @@ define create_tarball
 $(shell cd $(dir $(1)) \
     && find $(notdir $(1)) -print0 \
     | LC_ALL=C sort -z \
-    | tar c --mtime="$(GIT_DATE)" \
+    | $(TAR) c --mtime="$(GIT_DATE)" \
             --owner=root --group=root --numeric-owner \
             --no-recursion --null -T - -f - \
     | gzip -9n > "$(2)")
@@ -70,7 +72,7 @@ endef
 $(OCTAVE_RELEASE): .git/index | $(BUILD_DIR)
 	@echo "Creating package version $(VERSION) release ..."
 	-$(RM) -r "$@"
-	git archive --format=tar --prefix="$@/" HEAD | tar -x
+	git archive --format=tar --prefix="$@/" HEAD | $(TAR) -x
 	$(RM) "$@/README.matlab.md" \
 	      "$@/.gitignore" \
 	      "$@/.travis.yml" \


### PR DESCRIPTION
Mostly fixes #216.

If you're on a BSD system that does not have GNU tar installed, it will still fall back to using the system BSD tar, and then create an empty tarball.