### PR TITLE
Enable pipefail for proper error propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help:
 GIT_DATE   := $(shell git show -s --format=\%ci)
 # Follows the recommendations of https://reproducible-builds.org/docs/archives
 define create_tarball
-$(shell cd $(dir $(1)) \
+$(shell set -o pipefail; cd $(dir $(1)) \
     && find $(notdir $(1)) -print0 \
     | LC_ALL=C sort -z \
     | $(TAR) c --mtime="$(GIT_DATE)" \


### PR DESCRIPTION
Fixes #216.

This sets the bash `pipefail` option, which causes the exit status of the pipeline to be the latest non-success status, instead of just the last element's status. This way, failures in the `tar` command will abort the build with a failure status.