### PR TITLE
Fix #224

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,12 @@ matlab_pkg: $(MATLAB_PKG_ZIP)
 ${MATLAB_PKG}: | $(BUILD_DIR) ${MATLAB_PKG}/private
 	$(OCTAVE) --path ${CURDIR}/util --silent --eval \
 		"convert_comments('inst/', '', '../${MATLAB_PKG}/')"
-	cp -ra inst/private/*.m ${MATLAB_PKG}/private/
-	cp -ra COPYING ${MATLAB_PKG}/
-	cp -ra CONTRIBUTORS ${MATLAB_PKG}/
-	cp -ra NEWS ${MATLAB_PKG}/
-	cp -ra README.matlab.md ${MATLAB_PKG}/
-	cp -ra test ${MATLAB_PKG}/
+	cp -a inst/private/*.m ${MATLAB_PKG}/private/
+	cp -a COPYING ${MATLAB_PKG}/
+	cp -a CONTRIBUTORS ${MATLAB_PKG}/
+	cp -a NEWS ${MATLAB_PKG}/
+	cp -a README.matlab.md ${MATLAB_PKG}/
+	cp -a test ${MATLAB_PKG}/
 
 matlab_test:
 	cd "${MATLAB_PKG}"; ${MATLAB} -nojvm -nodisplay -nosplash -r "${TEST_CODE}"


### PR DESCRIPTION
`-r` seems to be redundant here. `-a` already equals `-dR --preserve=all`, where `-R` is the same as `-r` on GNU/Linux according to [Ubuntu Manpages](https://manpages.ubuntu.com/manpages/bionic/en/man1/cp.1.html). I've tested on MacOS 10.14.6; getting the same results as with this [workaround](https://github.com/catch22/octave-doctest/issues/224#issue-495757630). Havn't tested on GNU/Linux yet.

See #224.