### PR TITLE
improve prompt matching in regex

### DIFF
--- a/inst/private/doctest_run_docstring.m
+++ b/inst/private/doctest_run_docstring.m
@@ -27,12 +27,13 @@ function results = doctest_run_docstring(docstring, defaults)
 % SPDX-License-Identifier: BSD-3-Clause
 
 
-% extract tests from docstring
-TEST_RE = [                                   % loosely based on Python 2.6 doctest.py, line 510
-    '(?m)(?-s)'                          ...  % options
-    '(?:^ *>> )'                         ...  % ">> "
-    '(.*(?:\n *\.\. .*)*)\n'             ...  % rest of line + ".. " lines
-    '((?:(?:^ *$\n)?(?!\s*>> ).*\S.*\n)*)'];  % the output
+PR = '>> ';
+% extract tests from docstring, regex loosely based on Python 2.6 doctest.py
+TEST_RE = [
+    '(?m)(?-s)'                             ...  % options
+    '(?:^ *' PR ')'                         ...  % prompt
+    '(.*(?:\n *\.\. .*)*)\n'                ...  % rest of line + ".. " lines
+    '((?:(?:^ *$\n)?(?!\s*' PR ').*\S.*\n)*)'];  % the output upto next prompt
 
 tests = [];
 test_matches = regexp(docstring, TEST_RE, 'tokens');

--- a/inst/private/doctest_run_docstring.m
+++ b/inst/private/doctest_run_docstring.m
@@ -32,7 +32,7 @@ TEST_RE = [                               % loosely based on Python 2.6 doctest.
     '(?m)(?-s)'                          ... % options
     '(?:^ *>> )'                         ... % ">> "
     '(.*(?:\n *\.\. .*)*)\n'             ... % rest of line + ".. " lines
-    '((?:(?:^ *$\n)?(?!\s*>>).*\S.*\n)*)'];  % the output
+    '((?:(?:^ *$\n)?(?!\s*>> ).*\S.*\n)*)'];  % the output
 
 tests = [];
 test_matches = regexp(docstring, TEST_RE, 'tokens');

--- a/inst/private/doctest_run_docstring.m
+++ b/inst/private/doctest_run_docstring.m
@@ -31,7 +31,7 @@ PR = '>> ';
 % extract tests from docstring, regex loosely based on Python 2.6 doctest.py
 TEST_RE = [
     '(?m)(?-s)'                             ...  % options
-    '(?:^ *' PR ')'                         ...  % prompt
+    '(?:^\s*' PR ')'                        ...  % prompt
     '(.*(?:\n *\.\. .*)*)\n'                ...  % rest of line + ".. " lines
     '((?:(?:^ *$\n)?(?!\s*' PR ').*\S.*\n)*)'];  % the output upto next prompt
 

--- a/inst/private/doctest_run_docstring.m
+++ b/inst/private/doctest_run_docstring.m
@@ -28,10 +28,10 @@ function results = doctest_run_docstring(docstring, defaults)
 
 
 % extract tests from docstring
-TEST_RE = [                               % loosely based on Python 2.6 doctest.py, line 510
-    '(?m)(?-s)'                          ... % options
-    '(?:^ *>> )'                         ... % ">> "
-    '(.*(?:\n *\.\. .*)*)\n'             ... % rest of line + ".. " lines
+TEST_RE = [                                   % loosely based on Python 2.6 doctest.py, line 510
+    '(?m)(?-s)'                          ...  % options
+    '(?:^ *>> )'                         ...  % ">> "
+    '(.*(?:\n *\.\. .*)*)\n'             ...  % rest of line + ".. " lines
     '((?:(?:^ *$\n)?(?!\s*>> ).*\S.*\n)*)'];  % the output
 
 tests = [];

--- a/test/bist.m
+++ b/test/bist.m
@@ -154,3 +154,8 @@ end
 %! assert (t1 == t2)
 %! assert (summ1.num_targets == summ2.num_targets)
 %! assert (summ2.num_targets_with_extraction_errors == 0)
+
+%!test
+%! % correct number of tests
+%! [n, t, summ] = doctest('test_tab_before_prompt');
+%! assert (n == 2)

--- a/test/bist.m
+++ b/test/bist.m
@@ -159,3 +159,8 @@ end
 %! % correct number of tests
 %! [n, t, summ] = doctest('test_tab_before_prompt');
 %! assert (n == 2)
+
+%!test
+%! % correct number of error tests
+%! [n, t, summ] = doctest('test_error');
+%! assert (t == 4)

--- a/test/test_error.m
+++ b/test/test_error.m
@@ -1,0 +1,29 @@
+function test_error()
+%
+% Copyright (c) 2019 Colin B. Macdonald
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% >> a = 42
+% a = 42
+%
+%
+% >> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
+% ??? parse error:
+%
+% syntax error
+% >>> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
+%               ^
+%
+%
+% Annoyingly, we the doctest directive is still there and
+% appears in the error mesage.  Perhaps we should move these
+% tests to bist.m.
+%
+% >> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
+% ??? parse error:
+%
+% syntax error
+% >>> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
+%               ^
+% >> a = 43
+% a = 43

--- a/test/test_tab_before_prompt.m
+++ b/test/test_tab_before_prompt.m
@@ -1,0 +1,14 @@
+function test_tab_before_prompt()
+%
+% Copyright (c) 2019 Colin B. Macdonald
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% This first test has spaces
+%       >> a = 42
+%       a = 42
+%
+%	>> a = 43
+%	a = 43
+%
+%
+% The second one has tabs: there should be two tests.


### PR DESCRIPTION
Fixes #237 by adding a blank space to the prompt.

Factor the prompt itself out of the regex.

There was some inconsistency about `\s*` or ` *`: I assume that was an accident and used `\s*` before the prompt in both the beginning and end of the test.  Added a test for this.