### PR TITLE
Remove `???` from Octave/Matlab errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ doctest 0.7.0+
 
   * `doctest myclass` has been refactored with various bugs fixed.
 
-  * Functions defined directly in the Octave interpretor can now be tested.
+  * Functions defined directly in the Octave interpreter can now be tested.
 
 
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 doctest 0.7.0+
 ==============
 
+  * Expected error messages can be optionally prefixed with "error: ".
+
+  * Writing "??? " at the beginning of an error is now deprecated.
+
+  * Texinfo users can markup errors with `@error{}`.
+
   * `doctest myclass` has been refactored with various bugs fixed.
 
   * Functions defined directly in the Octave interpreter can now be tested.

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -98,15 +98,14 @@
 %% @example
 %% @group
 %% >> not_a_real_function(42)
-%% ...ndefined ...
+%% error: ...ndefined ...
 %% @end group
 %% @end example
-%% (Note use of wildcards here; MATLAB spells this 'Undefined', while Octave
-%% uses 'undefined').
 %%
-%% However, currently this does not work if the code emits other output
-%% @strong{before} the error message.  Warnings are different; they work
-%% fine.
+%% Note use of wildcards here; MATLAB spells this @code{Undefined}, while
+%% Octave uses @code{undefined}.  Writing @code{error: } is optional.
+%% Currently errors do not work if the code emits other output before the
+%% error message.  Warnings are different; they work fine.
 %%
 %%
 %% @strong{Multiple lines of code}

--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -98,7 +98,7 @@
 %% @example
 %% @group
 %% >> not_a_real_function(42)
-%% ??? ...ndefined ...
+%% ...ndefined ...
 %% @end group
 %% @end example
 %% (Note use of wildcards here; MATLAB spells this 'Undefined', while Octave

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -484,7 +484,7 @@ function [docstring, error] = parse_texinfo(str)
       % First nonblank line starts with '>>': assume diary style.  However,
       % we strip @result and @print macros (TODO: perhaps unwisely?)
       L = strsplit (T{i}, '\n');
-      L = regexprep (L, '^(\s*)(?:⇒|=>|⊣|-\||error→|error->|)', '$1', 'once', 'lineanchors');
+      L = regexprep (L, '^(\s*)(?:⇒|=>|⊣|-\||error→|error->)', '$1', 'once', 'lineanchors');
       T{i} = strjoin (L, '\n');
       continue
     end
@@ -493,7 +493,7 @@ function [docstring, error] = parse_texinfo(str)
     % Hack: the @example block is commonly mis-used to store non-examples such as
     % diagrams or math.  Delete an example block that has no indicated output.
     % (Hard to leave for "later" as we don't keep track of @example blocks.)
-    R1 = regexp (T{i}, '^\s*(⇒|=>|⊣|-\||error→|error->|)', 'lineanchors');
+    R1 = regexp (T{i}, '^\s*(⇒|=>|⊣|-\||error→|error->)', 'lineanchors');
     R2 = regexp (T{i}, '(doctest:\s+-TEXINFO_SKIP_BLOCKS_WO_OUTPUT)');
     T{i} = regexprep (T{i}, '(doctest:\s+-TEXINFO_SKIP_BLOCKS_WO_OUTPUT)', '');
     if (isempty (R1) && isempty (R2))
@@ -507,7 +507,7 @@ function [docstring, error] = parse_texinfo(str)
     % Categorize input and output lines in the example using
     % @result and @print macros.  Everything else, including comment lines and
     % empty lines, is categorized as input (for now).
-    Linput = cellfun ('isempty', regexp (L, '^\s*(⇒|=>|⊣|-\||error→|error->|)', 'once'));
+    Linput = cellfun ('isempty', regexp (L, '^\s*(⇒|=>|⊣|-\||error→|error->)', 'once'));
 
     if (not (Linput (1)))
       error = 'no command: @result on first line?';
@@ -556,7 +556,7 @@ function [docstring, error] = parse_texinfo(str)
     % strip @result and @print macro output
     Loutput = not (Linput);
     L(Loutput) = regexprep (L(Loutput), ...
-                            '^(\s*)(?:⇒|=>|⊣|-\||error→|error->|)', ...
+                            '^(\s*)(?:⇒|=>|⊣|-\||error→|error->)', ...
                             '$1', ...
                             'once', 'lineanchors');
 

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -484,7 +484,7 @@ function [docstring, error] = parse_texinfo(str)
       % First nonblank line starts with '>>': assume diary style.  However,
       % we strip @result and @print macros (TODO: perhaps unwisely?)
       L = strsplit (T{i}, '\n');
-      L = regexprep (L, '^(\s*)(?:⇒|=>|⊣|-\|)', '$1', 'once', 'lineanchors');
+      L = regexprep (L, '^(\s*)(?:⇒|=>|⊣|-\||error→|error->|)', '$1', 'once', 'lineanchors');
       T{i} = strjoin (L, '\n');
       continue
     end
@@ -493,7 +493,7 @@ function [docstring, error] = parse_texinfo(str)
     % Hack: the @example block is commonly mis-used to store non-examples such as
     % diagrams or math.  Delete an example block that has no indicated output.
     % (Hard to leave for "later" as we don't keep track of @example blocks.)
-    R1 = regexp (T{i}, '^\s*(⇒|=>|⊣|-\|)', 'lineanchors');
+    R1 = regexp (T{i}, '^\s*(⇒|=>|⊣|-\||error→|error->|)', 'lineanchors');
     R2 = regexp (T{i}, '(doctest:\s+-TEXINFO_SKIP_BLOCKS_WO_OUTPUT)');
     T{i} = regexprep (T{i}, '(doctest:\s+-TEXINFO_SKIP_BLOCKS_WO_OUTPUT)', '');
     if (isempty (R1) && isempty (R2))
@@ -507,7 +507,7 @@ function [docstring, error] = parse_texinfo(str)
     % Categorize input and output lines in the example using
     % @result and @print macros.  Everything else, including comment lines and
     % empty lines, is categorized as input (for now).
-    Linput = cellfun ('isempty', regexp (L, '^\s*(⇒|=>|⊣|-\|)', 'once'));
+    Linput = cellfun ('isempty', regexp (L, '^\s*(⇒|=>|⊣|-\||error→|error->|)', 'once'));
 
     if (not (Linput (1)))
       error = 'no command: @result on first line?';
@@ -556,7 +556,7 @@ function [docstring, error] = parse_texinfo(str)
     % strip @result and @print macro output
     Loutput = not (Linput);
     L(Loutput) = regexprep (L(Loutput), ...
-                            '^(\s*)(?:⇒|=>|⊣|-\|)', ...
+                            '^(\s*)(?:⇒|=>|⊣|-\||error→|error->|)', ...
                             '$1', ...
                             'once', 'lineanchors');
 

--- a/inst/private/doctest_format_exception.m
+++ b/inst/private/doctest_format_exception.m
@@ -13,22 +13,18 @@ function formatted = doctest_format_exception(ex)
 
 
   if is_octave()
-    if (regexp (ex.message, '^parse error:'))
-      formatted = strtrim(ex.message);
-    else
-      formatted = ['error: ' strtrim(ex.message)];
-    end
+    formatted = strtrim(ex.message);
     return
   end
 
-% matlab!
-if strcmp(ex.stack(1).name, 'doctest_run_tests')
+
+  if strcmp(ex.stack(1).name, 'doctest_run_tests')
   % we don't want the report, we just want the message
   % otherwise it'll talk about evalc, which is not what the user got on
   % the command line.
-  formatted = ['??? ' ex.message];
-else
-  formatted = ['??? ' ex.getReport('basic')];
-end
+    formatted = ex.message;
+  else
+    formatted = ex.getReport('basic');
+  end
 
 end

--- a/inst/private/doctest_format_exception.m
+++ b/inst/private/doctest_format_exception.m
@@ -12,11 +12,14 @@ function formatted = doctest_format_exception(ex)
 % SPDX-License-Identifier: BSD-3-Clause
 
 
-% octave?
-if is_octave()
-  formatted = ['??? ' strtrim(ex.message)];
-  return
-end
+  if is_octave()
+    if (regexp (ex.message, '^parse error:'))
+      formatted = strtrim(ex.message);
+    else
+      formatted = ['error: ' strtrim(ex.message)];
+    end
+    return
+  end
 
 % matlab!
 if strcmp(ex.stack(1).name, 'doctest_run_tests')

--- a/inst/private/doctest_run_tests.m
+++ b/inst/private/doctest_run_tests.m
@@ -57,6 +57,7 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
     DOCTEST__current_test.got = strcat('There was a problem executing +SKIP directive:', ...
                                        sprintf('\n'), ...
                                        doctest_format_exception(DOCTEST__exception));
+    DOCTEST__current_test.goterr = true;
     DOCTEST__current_test.passed = false;
   end
 
@@ -73,6 +74,7 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
     DOCTEST__current_test.got = strcat('problem executing +XFAIL directive:', ...
                                        sprintf('\n'), ...
                                        doctest_format_exception(DOCTEST__exception));
+    DOCTEST__current_test.goterr = true;
     DOCTEST__current_test.passed = false;
   end
 
@@ -85,17 +87,24 @@ for DOCTEST__i = 1:numel(DOCTEST__tests)
   % run the test code
   try
     DOCTEST__got = evalc(DOCTEST__current_test.source);
+    DOCTEST__goterr = false;
   catch DOCTEST__exception
     DOCTEST__got = doctest_format_exception(DOCTEST__exception);
+    DOCTEST__goterr = true;
   end
 
   % at this point, we can only rely on the DOCTEST__got variable
   % being available
   DOCTEST__current_test = doctest_datastore('get_current_test');
   DOCTEST__current_test.got = DOCTEST__got;
+  DOCTEST__current_test.goterr = DOCTEST__goterr;
 
   % determine if test has passed
-  DOCTEST__current_test.passed = doctest_compare(DOCTEST__current_test.want, DOCTEST__current_test.got, DOCTEST__current_test.normalize_whitespace, DOCTEST__current_test.ellipsis);
+  DOCTEST__current_test.passed = doctest_compare(DOCTEST__current_test.want, ...
+                                                 DOCTEST__current_test.got, ...
+                                                 DOCTEST__current_test.goterr, ...
+                                                 DOCTEST__current_test.normalize_whitespace, ...
+                                                 DOCTEST__current_test.ellipsis);
   if DOCTEST__current_test.xfail
     DOCTEST__current_test.passed = ~DOCTEST__current_test.passed;
   end

--- a/test/test_clear.m
+++ b/test/test_clear.m
@@ -6,13 +6,13 @@ function test_clear()
 % >> b
 % b =  7
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % Harder:
 % >> clear
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % >> a = 4
@@ -22,7 +22,7 @@ function test_clear()
 % "clear all" clears stuff inside persistent vars
 % >> clear all
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % >> a = 5

--- a/test/test_clear_all_first.m
+++ b/test/test_clear_all_first.m
@@ -3,7 +3,7 @@ function test_clear_all_first()
 % subfunctions haven't yet been called.  At least on Octave 4.2.1.
 % >> clear all
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % >> a = 6

--- a/test/test_clear_isoctave.m
+++ b/test/test_clear_isoctave.m
@@ -6,12 +6,12 @@ function test_clear_isoctave()
 %
 % >> clear
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % >> clear all
 % >> a
-% ??? ...ndefined ...
+% ...ndefined ...
 %
 %
 % Make sure these macros are still available after a clear

--- a/test/test_deprecated.m
+++ b/test/test_deprecated.m
@@ -1,0 +1,10 @@
+function test_deprecated()
+%
+% Copyright (c) 2019 Colin B. Macdonald
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% "??? " for errors deprecated 2019-10
+% >> nosuchfcn(42)
+% ??? ...ndefined...
+%
+%

--- a/test/test_error.m
+++ b/test/test_error.m
@@ -8,7 +8,7 @@ function test_error()
 %
 %
 % >> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
-% ??? parse error:
+% parse error:
 %
 % syntax error
 % >>> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
@@ -20,7 +20,7 @@ function test_error()
 % tests to bist.m.
 %
 % >> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)
-% ??? parse error:
+% parse error:
 %
 % syntax error
 % >>> 2 + (1 + !))   % doctest: +XFAIL_IF(DOCTEST_MATLAB)

--- a/test/test_error.texinfo
+++ b/test/test_error.texinfo
@@ -3,7 +3,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 @example
 2 + (1 + !))
-  @error{} ??? parse error:
+  @error{} parse error:
   @error{}
   @error{} syntax error
   @error{} >>> 2 + (1 + !))
@@ -11,14 +11,6 @@ SPDX-License-Identifier: BSD-3-Clause
 @end example
 
 @example
-nosuchfcn(42)
-  @error{} ??? 'nosuchfcn' undefined near line 1 column 1
-@end example
-
-Consider adjusting the above tests, removing @code{???},
-after @url{https://github.com/catch22/octave-doctest/issues/238}
-@example
-@c doctest: +XFAIL
 nosuchfcn(42)
   @error{} error: 'nosuchfcn' undefined near line 1 column 1
 @end example

--- a/test/test_error.texinfo
+++ b/test/test_error.texinfo
@@ -1,0 +1,36 @@
+Copyright (c) 2019 Colin B. Macdonald
+SPDX-License-Identifier: BSD-3-Clause
+
+@example
+2 + (1 + !))
+  @error{} ??? parse error:
+  @error{}
+  @error{} syntax error
+  @error{} >>> 2 + (1 + !))
+  @error{}               ^
+@end example
+
+@example
+nosuchfcn(42)
+  @error{} ??? 'nosuchfcn' undefined near line 1 column 1
+@end example
+
+Consider adjusting the above tests, removing @code{???},
+after @url{https://github.com/catch22/octave-doctest/issues/238}
+@example
+@c doctest: +XFAIL
+nosuchfcn(42)
+  @error{} error: 'nosuchfcn' undefined near line 1 column 1
+@end example
+
+
+In symbolic I had a failure when a test contained more code after an
+error.  It did not pass without careful treatment of the typography of
+the texinfo error macro.
+@example
+a = 3;
+b = nosuchfcn(a)
+  @error{} ... undefined...
+c = inv(a)
+  @result{} c = 0.33333
+@end example

--- a/test/test_error.texinfo
+++ b/test/test_error.texinfo
@@ -15,6 +15,15 @@ nosuchfcn(42)
   @error{} error: 'nosuchfcn' undefined near line 1 column 1
 @end example
 
+@example
+nosuchfcn(42)
+  @print{} error: 'nosuchfcn' undefined near line 1 column 1
+@end example
+
+@example
+nosuchfcn(42)
+  @error{} 'nosuchfcn' undefined near line 1 column 1
+@end example
 
 In symbolic I had a failure when a test contained more code after an
 error.  It did not pass without careful treatment of the typography of


### PR DESCRIPTION
    In most cases, prepend `error: ` like Octave does.  In special cases
    (currently `parse error:` but maybe others later) we do not do this
    prepending.
    
    This is a partial fix for Issue #238.  But no changes yet on Matlab
    and no deprecation of `???`.
