### PR TITLE
test: CP1252 encoding, check utf-8 conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ MATLAB ?= matlab
 
 TEST_CODE=ver(), success = doctest({'doctest', 'test/', 'test/examples/'}); exit(~success);
 # run tests twice so we can see some output
-BIST_CODE=ver(), cd('test'); disp(pwd()), test('bist'); success1 = test('bist'); cd('..'); cd('test_extra'); disp(pwd()), test('run_tests'); success2 = test('run_tests'); exit(~success1) || ~success2;
+BIST_CODE=ver(), cd('test'); disp(pwd()), test('bist'); success1 = test('bist'); cd('..'); cd('test_extra'); disp(pwd()), test('run_tests'); success2 = test('run_tests'); exit(~success1 || ~success2);
 
 
 .PHONY: help clean install test test-interactive dist html matlab_test matlab_pkg

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -32,31 +32,37 @@
 
 %!test
 %! %% test for file that is not encoded in UTF-8
-%! % A bug in Octave 7 requires that the folder containing the .oct-config file
-%! % is in the load path (not the current folder).
-%! path_orig = path ();
-%! path_protect = onCleanup (@() path (path_orig));
-%!
-%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
-%!   warning ('TODO: will be noisy: learn how to enquiet...')
+%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
+%!   if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
+%!     warning ('TODO: will be noisy: learn how to enquiet...')
+%!   end
+%!   % A bug in Octave 7 requires that the folder containing the .oct-config file
+%!   % is in the load path (not the current folder).
+%!   path_orig = path ();
+%!   unwind_protect
+%!     addpath (canonicalize_file_name ('test_encoding'));
+%!     success = doctest ('test_CP1252.m', '-quiet');
+%!     assert (success)
+%!   unwind_protect_cleanup
+%!     path (path_orig)
+%!   end
 %! end
-%! addpath (canonicalize_file_name ('test_encoding'));
-%! success = doctest ('test_CP1252.m', '-quiet');
-%! assert (success)
-%! clear path_protect;
 
 %!test
 %! %% CP1252 to UTF-8 internally, check byte counts
-%! path_orig = path ();
-%! path_protect = onCleanup (@() path (path_orig));
-%!
-%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
-%!   warning ('TODO: will be noisy: learn how to enquiet...')
+%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
+%!   if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
+%!     warning ('TODO: will be noisy: learn how to enquiet...')
+%!   end
+%!   path_orig = path ();
+%!   unwind_protect
+%!     addpath (canonicalize_file_name ('test_encoding'));
+%!     success = doctest ('test_bytecount_CP1252.m', '-quiet');
+%!     assert (success)
+%!   unwind_protect_cleanup
+%!     path (path_orig)
+%!   end
 %! end
-%! addpath (canonicalize_file_name ('test_encoding'));
-%! success = doctest ('test_bytecount_CP1252.m', '-quiet');
-%! assert (success)
-%! clear path_protect;
 
 %!test
 %! %% On Octave 8, we can go to the actual directory

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -37,11 +37,12 @@
 %! path_orig = path ();
 %! path_protect = onCleanup (@() path (path_orig));
 %!
-%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '>='))
-%!   addpath (canonicalize_file_name ('test_encoding'));
-%!   success = doctest ('test_CP1252.m', '-quiet');
-%!   assert (success)
+%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
+%!   warning ('TODO: will be noisy: learn how to enquiet...')
 %! end
+%! addpath (canonicalize_file_name ('test_encoding'));
+%! success = doctest ('test_CP1252.m', '-quiet');
+%! assert (success)
 %! clear path_protect;
 
 %!test
@@ -49,9 +50,23 @@
 %! path_orig = path ();
 %! path_protect = onCleanup (@() path (path_orig));
 %!
-%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '>='))
-%!   addpath (canonicalize_file_name ('test_encoding'));
-%!   success = doctest ('test_bytecount_CP1252.m', '-quiet');
-%!   assert (success)
+%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
+%!   warning ('TODO: will be noisy: learn how to enquiet...')
 %! end
+%! addpath (canonicalize_file_name ('test_encoding'));
+%! success = doctest ('test_bytecount_CP1252.m', '-quiet');
+%! assert (success)
 %! clear path_protect;
+
+%!test
+%! %% On Octave 8, we can go to the actual directory
+%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '>='))
+%!   d = pwd ();
+%!   unwind_protect
+%!     cd ('test_encoding');
+%!     success = doctest ('test_bytecount_CP1252.m', '-quiet');
+%!     assert (success)
+%!   unwind_protect_cleanup
+%!     cd (d)
+%!   end
+%! end

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -43,3 +43,15 @@
 %!   assert (success)
 %! end
 %! clear path_protect;
+
+%!test
+%! %% CP1252 to UTF-8 internally, check byte counts
+%! path_orig = path ();
+%! path_protect = onCleanup (@() path (path_orig));
+%!
+%! if (compare_versions (OCTAVE_VERSION(), '8.0.0', '>='))
+%!   addpath (canonicalize_file_name ('test_encoding'));
+%!   success = doctest ('test_bytecount_CP1252.m', '-quiet');
+%!   assert (success)
+%! end
+%! clear path_protect;

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -31,15 +31,14 @@
 
 
 %!test
-%! %% test for file that is not encoded in UTF-8
+%! %% test with file that is not encoded in UTF-8
 %! % this is a bare minimal test: the file is probably not read correctly
 %! % until Octave >= 7.0.0.
 %! path_orig = path ();
 %! warn_orig = warning ('off', 'octave:get_input:invalid_utf8');
 %! unwind_protect
 %!   addpath (canonicalize_file_name ('test_encoding'));
-%!   success = doctest ('test_CP1252.m', '-quiet');
-%!   assert (success)
+%!   assert (doctest ('test_CP1252.m', '-quiet'));
 %! unwind_protect_cleanup
 %!   path (path_orig)
 %!   warning (warn_orig)
@@ -53,8 +52,7 @@
 %!   path_orig = path ();
 %!   unwind_protect
 %!     addpath (canonicalize_file_name ('test_encoding'));
-%!     success = doctest ('test_bytecount_CP1252.m', '-quiet');
-%!     assert (success)
+%!     assert (doctest ('test_bytecount_CP1252.m', '-quiet'));
 %!   unwind_protect_cleanup
 %!     path (path_orig)
 %!   end
@@ -66,8 +64,7 @@
 %!   d = pwd ();
 %!   unwind_protect
 %!     cd ('test_encoding');
-%!     success = doctest ('test_bytecount_CP1252.m', '-quiet');
-%!     assert (success)
+%!     assert (doctest ('test_bytecount_CP1252.m', '-quiet'));
 %!   unwind_protect_cleanup
 %!     cd (d)
 %!   end

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -32,28 +32,23 @@
 
 %!test
 %! %% test for file that is not encoded in UTF-8
-%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
-%!   if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
-%!     warning ('TODO: will be noisy: learn how to enquiet...')
-%!   end
-%!   % A bug in Octave 7 requires that the folder containing the .oct-config file
-%!   % is in the load path (not the current folder).
-%!   path_orig = path ();
-%!   unwind_protect
-%!     addpath (canonicalize_file_name ('test_encoding'));
-%!     success = doctest ('test_CP1252.m', '-quiet');
-%!     assert (success)
-%!   unwind_protect_cleanup
-%!     path (path_orig)
-%!   end
+%! % this is a bare minimal test: the file is probably not read correctly
+%! % until Octave >= 7.0.0.
+%! % TODO: need to silence some warnings here on Octave 6.x and 7.x?
+%! path_orig = path ();
+%! unwind_protect
+%!   addpath (canonicalize_file_name ('test_encoding'));
+%!   success = doctest ('test_CP1252.m', '-quiet');
+%!   assert (success)
+%! unwind_protect_cleanup
+%!   path (path_orig)
 %! end
 
 %!test
 %! %% CP1252 to UTF-8 internally, check byte counts
+%! % A bug in Octave 7 requires that the folder containing the .oct-config file
+%! % is in the load path (not the current directory).
 %! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
-%!   if (compare_versions (OCTAVE_VERSION(), '8.0.0', '<'))
-%!     warning ('TODO: will be noisy: learn how to enquiet...')
-%!   end
 %!   path_orig = path ();
 %!   unwind_protect
 %!     addpath (canonicalize_file_name ('test_encoding'));

--- a/test_extra/run_tests.m
+++ b/test_extra/run_tests.m
@@ -34,14 +34,15 @@
 %! %% test for file that is not encoded in UTF-8
 %! % this is a bare minimal test: the file is probably not read correctly
 %! % until Octave >= 7.0.0.
-%! % TODO: need to silence some warnings here on Octave 6.x and 7.x?
 %! path_orig = path ();
+%! warn_orig = warning ('off', 'octave:get_input:invalid_utf8');
 %! unwind_protect
 %!   addpath (canonicalize_file_name ('test_encoding'));
 %!   success = doctest ('test_CP1252.m', '-quiet');
 %!   assert (success)
 %! unwind_protect_cleanup
 %!   path (path_orig)
+%!   warning (warn_orig)
 %! end
 
 %!test

--- a/test_extra/test_encoding/test_bytecount_CP1252.m
+++ b/test_extra/test_encoding/test_bytecount_CP1252.m
@@ -1,0 +1,36 @@
+%% Copyright (c) 2022 Colin B. Macdonald
+%%
+%% SPDX-License-Identifier: BSD-3-Clause
+
+%% -*- texinfo -*-
+%% @deftypefn {} {} test_bytecount_CP1252 ()
+%% Test function with some non-ASCII characters from CP1252
+%%
+%% This file is encoded in CP1252.  Here is the euro symbol:
+%% @example
+%% s = '€'
+%%   @result{} s = €
+%% @end example
+%%
+%% In CP1252, the euro symbol is encoded as a single byte.
+%% However, GNU Octave uses @code{utf-8} internally: when we
+%% load this docstring, it will have three bytes:
+%% @example
+%% double(s)
+%%   @result{}
+%%        226   130   172
+%% @end example
+%%
+%% Even better, we can look at the bits and compare to known
+%% values (e.g., see Wikipedia).
+%% @example
+%% uint8(s);
+%% dec2bin(ans)
+%%   @result{}
+%%        11100010  10000010  10101100
+%% @end example
+%% @end deftypefn
+
+function test_bytecount_CP1252 ()
+  % no-op
+endfunction


### PR DESCRIPTION
@mmuetzel I went and learning a little and tried to write a test that convinces me that the strings are being loaded properly into utf-8.

#### TODO

- [x] silence warnings on pre Octave 8
- [x] run encoding-related tests on Octave >= 7.
- [x] re: >= 7, it seems the current tests do not fail CI when they fail.
- [x] Fixes #257.