### PR TITLE
Octave: allow doctest class.method

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ doctest 0.7.0+
 
   * `doctest myclass` has been refactored with various bugs fixed.
 
+  * Preliminary support for `doctest classdef.method` on Octave.
+
   * Functions defined directly in the Octave interpreter can now be tested.
 
   * Test suite fixes for Octave 6.

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -60,6 +60,9 @@ if is_octave()
       type = 'dir';
     elseif (exist(w, 'file') || exist(w, 'builtin') || exist(w) == 103)
       type = 'function';
+    elseif (~isempty (help (w)))
+      % covers "doctest class.method" and (maybe in future) "doctest class/method"
+      type = 'function';
     else
       type = 'unknown';
     end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -60,13 +60,23 @@ if is_octave()
       type = 'dir';
     elseif (exist(w, 'file') || exist(w, 'builtin') || exist(w) == 103)
       type = 'function';
-    elseif (~isempty (help (w)))
-      % covers "doctest class.method" and (maybe in future) "doctest class/method"
-      type = 'function';
     else
       type = 'unknown';
     end
   end
+
+  % This covers anything that we can get help from that wasn't covered above,
+  % notably "doctest class.method".  Quite possibly some other things too.
+  if (strcmp (type, 'unknown'))
+    try
+      if (~isempty (help (w)))
+        type = 'function';
+      end
+    catch
+      % no-op
+    end
+  end
+
 else % Matlab
   if (strcmp(w(1), '@')) && ~isempty(methods(w(2:end)))
     % covers "doctest @class", but not "doctest @class/method"
@@ -80,6 +90,7 @@ else % Matlab
     type = 'function';
   elseif ~isempty(help(w))
     % covers "doctest class.method" and "doctest class/method"
+    % no try-catch needed as no error when w has no help
     type = 'function';
   else
     type = 'unknown';

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -77,7 +77,7 @@ else % Matlab
     type = 'function';
   elseif ~isempty(help(w))
     % covers "doctest class.method" and "doctest class/method"
-    type = 'function'
+    type = 'function';
   else
     type = 'unknown';
   end

--- a/test/bist.m
+++ b/test/bist.m
@@ -49,11 +49,12 @@ end
 %! assert (t2 < t1)
 
 %!test
+%! % maybe not recommended notation for classdef, but works for now...
 %! [nump, numt, summ] = doctest ('@test_classdef/amethod');
 %! assert (nump == 1 && numt == 1)
 
 %!xtest
-%! % https://github.com/catch22/octave-doctest/issues/92
+%! % maybe not recommended notation for classdef
 %! [nump, numt, summ] = doctest ('@test_classdef/disp');
 %! assert (nump == 1 && numt == 1)
 
@@ -111,12 +112,13 @@ end
 
 
 %!test
+%! % maybe not recommended notation for classdef, but currently at least no error
 %! % https://github.com/catch22/octave-doctest/issues/199
 %! [nump, numt, summ] = doctest ('@classdef_infile/disp');
 %! assert (nump >= 0)
 
 %!xtest
-%! % https://github.com/catch22/octave-doctest/issues/92
+%! % maybe not recommended notation for classdef
 %! [nump, numt, summ] = doctest ('@classdef_infile/disp');
 %! assert (nump == 1 && numt == 1)
 

--- a/test/bist.m
+++ b/test/bist.m
@@ -208,3 +208,35 @@ end
 %! % correct number of error tests
 %! [n, t, summ] = doctest('test_error');
 %! assert (t == 4)
+
+%!test
+%! % class inside a package
+%! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
+%!   [n, t, summary] = doctest ("containers.Map");
+%!   assert (n == t)
+%!   assert (summary.num_targets >= 10)  % lots of methods
+%! end
+
+%!test
+%! % classdef.method
+%! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
+%!   [n, t, summary] = doctest ("test_classdef.disp");
+%!   assert (n == t)
+%!   assert (n == 1)
+%! end
+
+%!test
+%! % classdef.method, where method is external file
+%! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
+%!   [n, t, summary] = doctest ("test_classdef.amethod");
+%!   assert (n == t)
+%!   assert (n == 1)
+%! end
+
+%!test
+%! % classdef.method
+%! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
+%!   [n, t, summary] = doctest ("classdef_infile.disp");
+%!   assert (n == t)
+%!   assert (n == 1)
+%! end


### PR DESCRIPTION
Fixes Issue #203.  Note that we still don't iterate over classes using
class.method: that is a later change for Issue #264.

#### todo

- [x] needs a test, perhaps a bist
- [x] identifiy precisely what octave this starts working on
    - Octave 6, tests protected on earlier versions