### PR TITLE
Use cls dot method for testing classdef classes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,9 @@ doctest 0.7.0+
 
   * Preliminary support for `doctest classdef.method` on Octave.
 
+  * Test classdef methods using dotted `classdef.method` while still
+    using `@class/method` on old-style classes.
+
   * Functions defined directly in the Octave interpreter can now be tested.
 
   * Test suite fixes for Octave 6.

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -278,10 +278,9 @@ function targets = collect_targets_class(w, depth)
     w = w(2:end);
   end
 
-  % TODO: workaround github.com/catch22/octave-doctest/issues/135 by
+  % workaround github.com/catch22/octave-doctest/issues/135 by
   % accessing all non-constructor method help text *before* "help obj"
-  if (false)
-  if (is_octave ())
+  if (is_octave () && compare_versions (OCTAVE_VERSION, '7.0.0', '<'))
     meths = methods (w);
     for i=1:numel (meths)
       if (~ strcmp (meths{i}, w))  % skip @obj/obj
@@ -290,7 +289,6 @@ function targets = collect_targets_class(w, depth)
       end
     end
   end  % end workaround
-  end
 
   % First, "help class".  For classdef, this differs from "help class.class"
   % (general class help vs constructor help).  For old-style classes we will

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -311,16 +311,17 @@ function targets = collect_targets_class(w, depth)
   for i=1:numel(meths)
     target = struct();
     if is_octave()
-      if compare_versions (OCTAVE_VERSION, '7.0.0', '<')
-        % TODO: also for old-style classes https://savannah.gnu.org/bugs/?61521
-        target.name = sprintf ('@%s%s%s', w, filesep (), meths{i});
-        target.link = '';
-      else
+      if compare_versions (OCTAVE_VERSION, '7.0.0', '>=') && exist (w, "class") == 8
+        % classdef on newish Octave: use cls.method
         if strcmp (meths{i}, w)
           % TODO: gathering the ctor help fails https://savannah.gnu.org/bugs/?62803
           continue
         end
         target.name = sprintf ('%s.%s', w, meths{i});
+        target.link = '';
+      else
+        % use @cls/method for old-style classes https://savannah.gnu.org/bugs/?61521
+        target.name = sprintf ('@%s%s%s', w, filesep (), meths{i});
         target.link = '';
       end
     else

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -316,6 +316,10 @@ function targets = collect_targets_class(w, depth)
         target.name = sprintf ('@%s%s%s', w, filesep (), meths{i});
         target.link = '';
       else
+        if strcmp (meths{i}, w)
+          % TODO: gathering the ctor help fails https://savannah.gnu.org/bugs/?62803
+          continue
+        end
         target.name = sprintf ('%s.%s', w, meths{i});
         target.link = '';
       end

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -280,6 +280,7 @@ function targets = collect_targets_class(w, depth)
 
   % TODO: workaround github.com/catch22/octave-doctest/issues/135 by
   % accessing all non-constructor method help text *before* "help obj"
+  if (false)
   if (is_octave ())
     meths = methods (w);
     for i=1:numel (meths)
@@ -289,6 +290,7 @@ function targets = collect_targets_class(w, depth)
       end
     end
   end  % end workaround
+  end
 
   % First, "help class".  For classdef, this differs from "help class.class"
   % (general class help vs constructor help).  For old-style classes we will
@@ -309,8 +311,14 @@ function targets = collect_targets_class(w, depth)
   for i=1:numel(meths)
     target = struct();
     if is_octave()
-      target.name = sprintf('@%s%s%s', w, filesep(), meths{i});
-      target.link = '';
+      if compare_versions (OCTAVE_VERSION, '7.0.0', '<')
+        % TODO: also for old-style classes https://savannah.gnu.org/bugs/?61521
+        target.name = sprintf ('@%s%s%s', w, filesep (), meths{i});
+        target.link = '';
+      else
+        target.name = sprintf ('%s.%s', w, meths{i});
+        target.link = '';
+      end
     else
       target.name = sprintf('%s.%s', w, meths{i});
       target.link = sprintf('<a href="matlab:editorservices.openAndGoToFunction(''%s'', ''%s'');">%s</a>', which(w), meths{i}, target.name);

--- a/test/bist.m
+++ b/test/bist.m
@@ -67,14 +67,21 @@ end
 %! %   * amethod in external file (1 test)
 %! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
 %!   [nump, numt, summ] = doctest ('test_classdef');
-%!   % only passes by coincidence! classhelp twice + amethod
-%!   % assert (nump == 5 && numt == 5)
-%!   assert (summ.num_targets == 4)
+%!   assert (nump == numt && numt >= 4)
+%!   assert (summ.num_targets >= 3)
 %! end
 
 %!xtest
+%! % https://github.com/catch22/octave-doctest/issues/268
+%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
+%!   [nump, numt, summ] = doctest ('classdef_infile');
+%!   assert (nump == numt && numt == 5)
+%!   assert (summ.num_targets == 4)
+%! end
+
+%!test
 %! %% Issue #220, Issue #261, clear and w/o special order or workarounds
-%! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
+%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
 %!   clear classes
 %!   % doctest ('test_classdef')
 %!   [numpass, numtest, summary] = doctest ('test_classdef');
@@ -130,8 +137,16 @@ end
 %! %   * disp method (1 test)
 %! if (compare_versions (OCTAVE_VERSION(), '6.0.0', '>='))
 %!   [nump, numt, summ] = doctest ('classdef_infile');
-%!   assert (nump == 4 && numt == 4)
+%!   assert (nump == numt && numt >= 3)
+%!   assert (summ.num_targets >= 2)
+%! end
+
+%!xtest
+%! % https://github.com/catch22/octave-doctest/issues/268
+%! if (compare_versions (OCTAVE_VERSION(), '7.0.0', '>='))
+%!   [nump, numt, summ] = doctest ('classdef_infile');
 %!   assert (summ.num_targets == 3)
+%!   assert (nump == numt && numt == 4)
 %! end
 
 %!test


### PR DESCRIPTION
Fixes #264.  Fixes #261.

I'm currently thinking to leave this for 0.9.0 as it seems like a big change.  OTOH, its clear `cls.method` is the best supported way of access classdef method help, and this falls back on `@cls/method` for old-style classes...

Maybe we can do a 0.8.0 and soon after do a 0.9.0.