### PR TITLE
CI: run octave 7.2.0 and "latest"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        octave: [4.2.0, 4.2.1, 4.2.2, 4.4.0, 4.4.1, 5.1.0, 5.2.0, 6.1.0, 6.2.0, 6.3.0, 6.4.0, 7.1.0]
+        octave: [4.2.0, 4.2.1, 4.2.2, 4.4.0, 4.4.1, 5.1.0, 5.2.0, 6.1.0, 6.2.0, 6.3.0, 6.4.0, 7.1.0, 7.2.0, latest]
     steps:
       - uses: actions/checkout@v3
       - name: Container setup


### PR DESCRIPTION
"latest" is currently just 7.2.0 but I think this future proofs things a bit.

Fixes #270.