### PR TITLE
Classdef handle delete workaround

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ doctest 0.8.0+
 
   * Development repo moved to https://github.com/gnu-octave/octave-doctest
 
+  * Fixes for Octave 9 and Octave 10.
+
+  * Workaround for delete method of subclasses of "handle".
+
 
 
 doctest 0.8.0 (2023-01-03)

--- a/inst/private/doctest_collect.m
+++ b/inst/private/doctest_collect.m
@@ -10,7 +10,7 @@ function summary = doctest_collect(w, directives, summary, recursive, verbose, d
 %%
 % Copyright (c) 2010 Thomas Grenfell Smith
 % Copyright (c) 2015 Michael Walter
-% Copyright (c) 2015-2019, 2022-2024 Colin B. Macdonald
+% Copyright (c) 2015-2019, 2022-2025 Colin B. Macdonald
 % Copyright (c) 2015 Oliver Heimlich
 % Copyright (C) 2018 Mike Miller
 % SPDX-License-Identifier: BSD-3-Clause
@@ -377,8 +377,12 @@ function [docstring, error] = extract_docstring(name)
       assert (isempty (docstring))
       error = '';
     elseif strcmp(format, 'Not found')
-      % looks like "doctest test_no_docs.m" gets us here: octave bug?
       if (regexp(name,'\.m$'))
+        % looks like "doctest test_no_docs.m" gets us here: octave bug?
+        assert (isempty (docstring))
+        error = '';
+      elseif (is_octave() && compare_versions (OCTAVE_VERSION(), '9.0.0', '>=') && regexp(name,'.+\.delete$'))
+        % forgive mssing "classdef.delete", which Octave 9 "methods" adds to handle-classes
         assert (isempty (docstring))
         error = '';
       else

--- a/test/bist.m
+++ b/test/bist.m
@@ -286,14 +286,18 @@ end
 
 %!test
 %! % classdef handle subclass delete behaviour
-%! [n, t, summary] = doctest ('cdef_subhandle1');
-%! assert (n == t)
-%! assert (n == 4)
-%! assert (summary.num_targets_with_extraction_errors == 0)
+%! if (compare_versions (OCTAVE_VERSION(), '9.0.0', '>='))
+%!   [n, t, summary] = doctest ('cdef_subhandle1');
+%!   assert (n == t)
+%!   assert (n == 4)
+%!   assert (summary.num_targets_with_extraction_errors == 0)
+%! end
 
 %!test
 %! % classdef handle subclass delete behaviour
-%! [n, t, summary] = doctest ('cdef_subhandle2');
-%! assert (n == t)
-%! assert (n == 3)
-%! assert (summary.num_targets_with_extraction_errors == 0)
+%! if (compare_versions (OCTAVE_VERSION(), '9.0.0', '>='))
+%!   [n, t, summary] = doctest ('cdef_subhandle2');
+%!   assert (n == t)
+%!   assert (n == 3)
+%!   assert (summary.num_targets_with_extraction_errors == 0)
+%! end

--- a/test/bist.m
+++ b/test/bist.m
@@ -283,3 +283,17 @@ end
 %!   assert (n == t)
 %!   assert (n == 1)
 %! end
+
+%!test
+%! % classdef handle subclass delete behaviour
+%! [n, t, summary] = doctest ('cdef_subhandle1');
+%! assert (n == t)
+%! assert (n == 4)
+%! assert (summary.num_targets_with_extraction_errors == 0)
+
+%!test
+%! % classdef handle subclass delete behaviour
+%! [n, t, summary] = doctest ('cdef_subhandle2');
+%! assert (n == t)
+%! assert (n == 3)
+%! assert (summary.num_targets_with_extraction_errors == 0)

--- a/test/cdef_subhandle1.m
+++ b/test/cdef_subhandle1.m
@@ -1,0 +1,23 @@
+classdef cdef_subhandle1 < handle
+% >> a = 42
+% a = 42
+
+  properties
+  end
+
+  methods
+    function obj = cdef_subhandle1()
+    end
+    function delete()
+      % >> a = 43
+      % a = 43
+    end
+    function disp(obj)
+      % >> a = 44
+      % a = 44
+      % >> a = a + 1
+      % a = 45
+      fprintf('hi')
+    end
+  end
+end

--- a/test/cdef_subhandle2.m
+++ b/test/cdef_subhandle2.m
@@ -1,0 +1,19 @@
+classdef cdef_subhandle2 < handle
+% >> a = 42
+% a = 42
+
+  properties
+  end
+
+  methods
+    function obj = cdef_subhandle2()
+    end
+    function disp(obj)
+      % >> a = 43
+      % a = 43
+      % >> a = a + 1
+      % a = 44
+      fprintf('hi')
+    end
+  end
+end


### PR DESCRIPTION
When a classdef is a subclass of handle, `methods(...)` returns `delete`, whether we actually have a "delete" method or not.  This leads to failures when we try to collect the non-existent method.

Workaround this.