### PR TITLE
include a BIST in doctest.m

### DIFF
--- a/inst/doctest.m
+++ b/inst/doctest.m
@@ -381,3 +381,8 @@ elseif nargout > 1
 end
 
 end
+
+
+%!test
+%! s = doctest ('doctest');
+%! assert (s)


### PR DESCRIPTION
This ensures that `pkg test doctest` at least does the same as running `doctest doctest`, namely running 16 doctests contained in `doctest.m`.

The full testsuite, run by `make test` and `make test-bist` are not integrated.

Fixes #297.  Well maybe not a complete fix.